### PR TITLE
通知アイコンからアップデートウィンドウが開かない問題を修正した

### DIFF
--- a/PeerCastStation/PeerCastStation.WPF/NotifyIconManager.cs
+++ b/PeerCastStation/PeerCastStation.WPF/NotifyIconManager.cs
@@ -111,7 +111,7 @@ namespace PeerCastStation.WPF
     {
       var item = new System.Windows.Forms.ToolStripMenuItem();
       item.Text = "アップデートのチェック(&U)";
-      item.Click += (sender, args) => this.owner.CheckVersion();
+      item.Click += (sender, args) => new UpdaterWindow().Show();
       return item;
     }
 


### PR DESCRIPTION
タスクトレイのコンテキストメニューにある「アップデートのチェック」をクリックしても何も起こらないようなので、アップデートウィンドウを表示するようにしました
