### PR TITLE
PeerCast.ChannelMonitorsをスレッドセーフにした

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/PeerCast.cs
+++ b/PeerCastStation/PeerCastStation.Core/PeerCast.cs
@@ -122,7 +122,8 @@ namespace PeerCastStation.Core
     /// <summary>
     /// チャンネル管理オブジェクトのリストを取得します
     /// </summary>
-    public IList<IChannelMonitor> ChannelMonitors { get; private set; }
+    public ReadOnlyCollection<IChannelMonitor> ChannelMonitors { get { return channelMonitors.AsReadOnly(); } }
+    private List<IChannelMonitor> channelMonitors = new List<IChannelMonitor>();
 
     /// <summary>
     /// チャンネルが追加された時に呼び出されます。
@@ -340,7 +341,6 @@ namespace PeerCastStation.Core
       this.SourceStreamFactories = new List<ISourceStreamFactory>();
       this.OutputStreamFactories = new List<IOutputStreamFactory>();
       this.ContentReaderFactories = new List<IContentReaderFactory>();
-      this.ChannelMonitors = new List<IChannelMonitor>();
       foreach (var addr in Dns.GetHostAddresses(Dns.GetHostName())) {
         switch (addr.AddressFamily) {
         case AddressFamily.InterNetwork:
@@ -371,6 +371,24 @@ namespace PeerCastStation.Core
       StartMonitor();
     }
 
+		public void AddChannelMonitor(IChannelMonitor monitor)
+		{
+			ReplaceCollection(ref channelMonitors, orig => {
+				var new_monitors = new List<IChannelMonitor>(orig);
+				new_monitors.Add(monitor);
+				return new_monitors;
+			});
+		}
+
+		public void RemoveChannelMonitor(IChannelMonitor monitor)
+		{
+			ReplaceCollection(ref channelMonitors, orig => {
+				var new_monitors = new List<IChannelMonitor>(orig);
+				new_monitors.Remove(monitor);
+				return new_monitors;
+			});
+		}
+
     private AutoResetEvent stoppedEvent = new AutoResetEvent(false);
     private RegisteredWaitHandle monitorThreadPool = null;
     private void StartMonitor()
@@ -380,10 +398,8 @@ namespace PeerCastStation.Core
           monitorThreadPool.Unregister(stoppedEvent);
         }
         else {
-          lock (ChannelMonitors) {
-            foreach (var monitor in ChannelMonitors) {
-              monitor.OnTimer();
-            }
+          foreach (var monitor in ChannelMonitors) {
+            monitor.OnTimer();
           }
         }
       }, null, 5000, false);

--- a/PeerCastStation/PeerCastStation.UI/PortMapper.cs
+++ b/PeerCastStation/PeerCastStation.UI/PortMapper.cs
@@ -65,13 +65,13 @@ namespace PeerCastStation.UI
 			base.OnStart();
 			if (!enabled) return;
 			monitor = new PortMapperMonitor(Application.PeerCast);
-			Application.PeerCast.ChannelMonitors.Add(monitor);
+			Application.PeerCast.AddChannelMonitor(monitor);
 		}
 
 		protected override void OnStop()
 		{
 			if (monitor!=null) {
-				Application.PeerCast.ChannelMonitors.Remove(monitor);
+				Application.PeerCast.RemoveChannelMonitor(monitor);
 				monitor.Dispose();
 				monitor = null;
 			}

--- a/PeerCastStation/PeerCastStation/PeerCastStation.cs
+++ b/PeerCastStation/PeerCastStation/PeerCastStation.cs
@@ -45,8 +45,8 @@ namespace PeerCastStation.Main
       foreach (var plugin in Plugins) {
         plugin.Attach(this);
       }
-      peerCast.ChannelMonitors.Add(new ChannelCleaner(peerCast));
-      peerCast.ChannelMonitors.Add(new ChannelNotifier(this));
+      peerCast.AddChannelMonitor(new ChannelCleaner(peerCast));
+      peerCast.AddChannelMonitor(new ChannelNotifier(this));
       LoadSettings();
       foreach (var plugin in Plugins) {
         plugin.Start();


### PR DESCRIPTION
#197 の修正

PeerCast.ChannelMonitorsはロックしなくても追加・削除ができるようになっており、競合して落ちる場合があったので、ChannelMonitorsは読み取り専用とし、AddChannelMonitor・RemoveChannelMonitorで追加・削除するようにした。
