### PR TITLE
Feature/ip growing

### DIFF
--- a/PeerCastStation/PeerCastStation.UI/PortMapper.cs
+++ b/PeerCastStation/PeerCastStation.UI/PortMapper.cs
@@ -94,7 +94,7 @@ namespace PeerCastStation.UI
 		: IChannelMonitor,
 		  IDisposable
 	{
-		private List<INatDevice> devices = new List<INatDevice>();
+		private ISet<INatDevice> devices = new HashSet<INatDevice>();
 		private List<int>        ports   = new List<int>();
 		private System.Diagnostics.Stopwatch timer = new System.Diagnostics.Stopwatch();
 		private PeerCast peerCast;
@@ -240,7 +240,9 @@ namespace PeerCastStation.UI
 		private void NatUtility_DeviceFound(object sender, DeviceEventArgs e)
 		{
 			lock (devices) {
-				devices.Add(e.Device);
+				if (!devices.Add(e.Device)) {
+					return;
+				}
 			}
 			lock (ports) {
 				foreach (var port in ports) {

--- a/PeerCastStation/PeerCastStation.UI/PortMapper.cs
+++ b/PeerCastStation/PeerCastStation.UI/PortMapper.cs
@@ -133,7 +133,7 @@ namespace PeerCastStation.UI
 		public IList<System.Net.IPAddress> GetExternalAddresses()
 		{
 			lock (devices) {
-				return devices.Select(dev => dev.GetExternalIP()).ToArray();
+				return devices.Select(dev => dev.GetExternalIP()).Distinct().ToArray();
 			}
 		}
 


### PR DESCRIPTION
![rapture_20150114175139](https://cloud.githubusercontent.com/assets/1272114/5740499/4cc58224-9c47-11e4-9eb4-6463ddea2da6.png)
こう、暫く起動しっぱにしていると同じIPが沢山表示されるのを何とかしました。

1. 既にリストにあるデバイスを追加しないようにしました
2. 同一IPがUPnPとNAT-PMPで2デバイス入るので重複分は表示しないようにしました