### PR TITLE
ソースURLのホスト部が0.0.0.0だった場合にエラーが発生しないように、ホスト部がIPアドレスの場合は名前の解決をしないようにした

### DIFF
--- a/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPSourceStream.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPSourceStream.cs
@@ -103,17 +103,23 @@ namespace PeerCastStation.FLV.RTMP
 
     private IPEndPoint GetBindAddress(Uri uri)
     {
-      try {
-        var address = Dns.GetHostAddresses(uri.DnsSafeHost)
-          .OrderBy(addr => addr.AddressFamily)
-          .FirstOrDefault();
-        var port = uri.Port;
-        if (address==null) return null;
-        return new IPEndPoint(address, port<0 ? 1935 : port);
+      IPAddress address;
+      if (uri.HostNameType==UriHostNameType.IPv4 ||
+          uri.HostNameType==UriHostNameType.IPv6) {
+        address = IPAddress.Parse(uri.Host);
       }
-      catch (SocketException) {
-        return null;
+      else {
+        try {
+          address = Dns.GetHostAddresses(uri.DnsSafeHost)
+            .OrderBy(addr => addr.AddressFamily)
+            .FirstOrDefault();
+          if (address == null) return null;
+        }
+        catch (SocketException) {
+          return null;
+        }
       }
+      return new IPEndPoint(address, uri.Port<0 ? 1935 : uri.Port);
     }
 
     protected override StreamConnection DoConnect(Uri source)

--- a/PeerCastStation/PeerCastStation.HTTP/HTTPSourceStream.cs
+++ b/PeerCastStation/PeerCastStation.HTTP/HTTPSourceStream.cs
@@ -136,7 +136,13 @@ namespace PeerCastStation.HTTP
     {
       try {
         client = new TcpClient();
-        client.Connect(source.DnsSafeHost, source.Port);
+        if (source.HostNameType==UriHostNameType.IPv4 ||
+            source.HostNameType==UriHostNameType.IPv6) {
+          client.Connect(IPAddress.Parse(source.Host), source.Port);
+        }
+        else {
+          client.Connect(source.DnsSafeHost, source.Port);
+        }
         var stream = client.GetStream();
         var connection = new StreamConnection(stream, stream);
         connection.ReceiveTimeout = 10000;


### PR DESCRIPTION
チャンネル作成時、ソースURLのホスト部に 0.0.0.0 を指定すると落ちます。
Windows 上だとエラーがファイルに記録されずログが取れなかったので Linux 上のものになりますが…

RTMPの場合：

    [ERROR] FATAL UNHANDLED EXCEPTION: System.ArgumentException: Addresses 0.0.0.0 (IPv4) and ::0 (IPv6) are unspecified addresses. You cannot use them as target address.
    Parameter name: hostNameOrAddress
      at System.Net.Dns.GetHostAddresses (System.String hostNameOrAddress) [0x00000] in <filename unknown>:0 
      at PeerCastStation.FLV.RTMP.RTMPSourceConnection.GetBindAddress (System.Uri uri) [0x00000] in <filename unknown>:0 
      at PeerCastStation.FLV.RTMP.RTMPSourceConnection.DoConnect (System.Uri source) [0x00000] in <filename unknown>:0 
      at PeerCastStation.Core.SourceConnectionBase.OnStarted () [0x00000] in <filename unknown>:0 
      at PeerCastStation.FLV.RTMP.RTMPSourceConnection.Run () [0x00000] in <filename unknown>:0 
      at PeerCastStation.Core.SourceStreamBase.<StartConnection>b__0 (System.Object state) [0x00000] in <filename unknown>:0 
      at System.Threading.Thread.StartInternal () [0x00000] in <filename unknown>:0 

HTTPの場合：

    [ERROR] FATAL UNHANDLED EXCEPTION: System.ArgumentException: Addresses 0.0.0.0 (IPv4) and ::0 (IPv6) are unspecified addresses. You cannot use them as target address.
    Parameter name: hostNameOrAddress
      at System.Net.Dns.GetHostAddresses (System.String hostNameOrAddress) [0x00000] in <filename unknown>:0 
      at System.Net.Sockets.TcpClient.Connect (System.String hostname, Int32 port) [0x00000] in <filename unknown>:0 
      at PeerCastStation.HTTP.HTTPSourceConnection.DoConnect (System.Uri source) [0x00000] in <filename unknown>:0 
      at PeerCastStation.Core.SourceConnectionBase.OnStarted () [0x00000] in <filename unknown>:0 
      at PeerCastStation.Core.SourceConnectionBase.Run () [0x00000] in <filename unknown>:0 
      at PeerCastStation.Core.SourceStreamBase.<StartConnection>b__0 (System.Object state) [0x00000] in <filename unknown>:0 
      at System.Threading.Thread.StartInternal () [0x00000] in <filename unknown>:0 
