### PR TITLE
therubyracerの追加

### DIFF
--- a/doc/Gemfile
+++ b/doc/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 gem 'kramdown'
 gem 'jekyll'
-
+gem 'therubyracer', :platforms => :ruby


### PR DESCRIPTION
readmeに従ってjekyll buildしたところ、"Could not find a JavaScript runtime."という内容のエラーが出ました。therubyracerを追加すれば直りました。

また、nodeがあればtherubyracerがなくてもbuildできたました。