### PR TITLE
kagamin2とwmrelayの対応のバグを修正

### DIFF
--- a/PeerCastStation/PeerCastStation.HTTP/HTTPSourceStream.cs
+++ b/PeerCastStation/PeerCastStation.HTTP/HTTPSourceStream.cs
@@ -187,7 +187,7 @@ namespace PeerCastStation.HTTP
           "Host: {1}\r\n" +
           "User-Agent: NSPlayer ({2})\r\n" +
           "Connection: close\r\n" +
-          "Pragma: stream-switch-count=2\r\n" +
+          "Pragma: stream-switch-count=1\r\n" +
           "\r\n",
           SourceUri.PathAndQuery,
           host,


### PR DESCRIPTION
kagamin2のC#版とwmrelayはペカステで受信できましたが。
kagamin2のC++版だとペカステで受信できないので修正しました。
修正したペカステだとkagamin2のC#版もwmrelayもkagamin2のC++版でも受信できました。
WMEとExpressionEncoderも受信できました。