### PR TITLE
kagamin2とwmrelayの対応のバグをさらに修正

### DIFF
--- a/PeerCastStation/PeerCastStation.HTTP/HTTPSourceStream.cs
+++ b/PeerCastStation/PeerCastStation.HTTP/HTTPSourceStream.cs
@@ -187,7 +187,7 @@ namespace PeerCastStation.HTTP
           "Host: {1}\r\n" +
           "User-Agent: NSPlayer ({2})\r\n" +
           "Connection: close\r\n" +
-          "Pragma: stream-switch-count=1\r\n" +
+          "Pragma: stream-switch\r\n" +
           "\r\n",
           SourceUri.PathAndQuery,
           host,


### PR DESCRIPTION
stream-switch-countはストリーム数のことでした。
stream-switch-countとストリーム数が一致してないとKagamin2に接続できませんでした。
たとえば動画と音声なら2、動画だけなら1、音声だけなら1と言った感じです
stream-switchだけにするとストリーム数がいくつでもKagamin2に接続できました。
WMEとMicrosoft Expression Encoder 4でも試しましたがちゃんと接続できました。