### PR TITLE
ポートチェックの頻度を上げる

### DIFF
--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/js/settings.js
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/js/settings.js
@@ -436,6 +436,7 @@ var SettingsViewModel = new function() {
 
   self.bind = function(target) {
     self.update();
+    self.checkPorts();
     updating = true;
     ko.applyBindings(self, target);
     updating = false;

--- a/PeerCastStation/PeerCastStation.UI/PCPPortChecker.cs
+++ b/PeerCastStation/PeerCastStation.UI/PCPPortChecker.cs
@@ -43,26 +43,9 @@ namespace PeerCastStation.UI
         .Where( listener => (listener.GlobalOutputAccepts & OutputStreamType.Relay)!=0)
         .Select(listener => listener.LocalEndPoint.Port);
       var checker = new PCPPortChecker(peercast.SessionID, TargetUri, ports);
-      return await checker.RunTaskAsync();
+      return await checker.RunAsync();
     }
   }
-
-  public class PortCheckCompletedEventArgs
-    : EventArgs
-  {
-    public bool     Success     { get; private set; }
-    public int[]    Ports       { get; private set; }
-    public TimeSpan ElapsedTime { get; private set; }
-
-    public PortCheckCompletedEventArgs(bool success, int[] ports, TimeSpan elapsed)
-      : base()
-    {
-      this.Success     = success;
-      this.Ports       = ports;
-      this.ElapsedTime = elapsed;
-    }
-  }
-  public delegate void PortCheckCompletedEventHandler(object sender, PortCheckCompletedEventArgs args);
 
   public class PortCheckResult
   {
@@ -91,7 +74,7 @@ namespace PeerCastStation.UI
       this.Ports = ports.ToArray();
     }
 
-    public async Task<PortCheckResult> RunTaskAsync()
+    public async Task<PortCheckResult> RunAsync()
     {
       var client = new WebClient();
       var data   = new JObject();
@@ -130,100 +113,6 @@ namespace PeerCastStation.UI
             stopwatch.Elapsed);
       }
     }
-
-    public void RunAsync()
-    {
-      var ctx = System.Threading.SynchronizationContext.Current;
-      System.Threading.ThreadPool.QueueUserWorkItem(state => {
-        var client = new WebClient();
-        var data   = new JObject();
-        data["instanceId"] = InstanceId.ToString("N");
-        data["ports"] = new JArray(Ports);
-        var succeeded = false;
-        var stopwatch = new System.Diagnostics.Stopwatch();
-        string response_body = null;
-        try {
-          stopwatch.Start();
-          var body = System.Text.Encoding.UTF8.GetBytes(data.ToString());
-          response_body = System.Text.Encoding.UTF8.GetString(client.UploadData(Target, body));
-          stopwatch.Stop();
-          succeeded = true;
-          var response = JToken.Parse(response_body);
-          var response_ports = response["ports"].Select(token => (int)token);
-          if (PortCheckCompleted!=null) {
-            ctx.Post(s => {
-              PortCheckCompleted(
-                this,
-                new PortCheckCompletedEventArgs(
-                  succeeded,
-                  response_ports.ToArray(),
-                  stopwatch.Elapsed));
-            }, null);
-          }
-        }
-        catch (WebException) {
-          succeeded = false;
-          if (PortCheckCompleted!=null) {
-            ctx.Post(s => {
-              PortCheckCompleted(
-                this,
-                new PortCheckCompletedEventArgs(
-                  succeeded,
-                  null,
-                  stopwatch.Elapsed));
-            }, null);
-          }
-        }
-        catch (Newtonsoft.Json.JsonReaderException) {
-          succeeded = false;
-          if (PortCheckCompleted!=null) {
-            ctx.Post(s => {
-              PortCheckCompleted(
-                this,
-                new PortCheckCompletedEventArgs(
-                  succeeded,
-                  null,
-                  stopwatch.Elapsed));
-            }, null);
-          }
-        }
-
-      });
-    }
-
-    public void Run()
-    {
-      var ctx = System.Threading.SynchronizationContext.Current;
-      var client = new WebClient();
-      var data   = new JObject();
-      data["instanceId"] = InstanceId.ToString("N");
-      data["ports"] = new JArray(Ports);
-      var succeeded = false;
-      var stopwatch = new System.Diagnostics.Stopwatch();
-      int[] response_ports = null;
-      try {
-        stopwatch.Start();
-        var body = System.Text.Encoding.UTF8.GetBytes(data.ToString());
-        var response_body = System.Text.Encoding.UTF8.GetString(client.UploadData(Target, body));
-        var response = JToken.Parse(response_body);
-        response_ports = response["ports"].Select(token => (int)token).ToArray();
-        stopwatch.Stop();
-        succeeded = true;
-      }
-      catch (WebException) {
-        succeeded = false;
-      }
-      if (PortCheckCompleted!=null) {
-        PortCheckCompleted(
-          this,
-          new PortCheckCompletedEventArgs(
-            succeeded,
-            response_ports,
-            stopwatch.Elapsed));
-      }
-    }
-
-    public event PortCheckCompletedEventHandler PortCheckCompleted;
   }
 
 }

--- a/PeerCastStation/PeerCastStation.UI/PCPPortChecker.cs
+++ b/PeerCastStation/PeerCastStation.UI/PCPPortChecker.cs
@@ -2,10 +2,52 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
+using PeerCastStation.Core;
 
 namespace PeerCastStation.UI
 {
+  [Plugin]
+  public class PCPPortCheckerPlugin
+    : PluginBase
+  {
+    public override string Name {
+      get { return "PCPPortCheckerPlugin"; }
+    }
+
+    public Uri TargetUri { get; set; }
+    public PCPPortCheckerPlugin()
+    {
+    }
+
+    protected override void OnStart()
+    {
+      var target_uri = TargetUri;
+      if (target_uri==null &&
+          AppSettingsReader.TryGetUri("PCPPortChecker", out target_uri)) {
+        TargetUri = target_uri;
+      }
+      base.OnStart();
+      CheckAsync()
+        .ContinueWith(prev => {
+          if (prev.IsCanceled || prev.IsFaulted) return;
+          this.Application.PeerCast.IsFirewalled = !prev.Result;
+        });
+    }
+
+    public async Task<bool> CheckAsync()
+    {
+      var peercast = Application.PeerCast;
+      var ports = peercast.OutputListeners
+        .Where( listener => (listener.GlobalOutputAccepts & OutputStreamType.Relay)!=0)
+        .Select(listener => listener.LocalEndPoint.Port);
+      var checker = new PCPPortChecker(peercast.SessionID, TargetUri, ports);
+      var result = await checker.RunTaskAsync();
+      return result.Success && result.Ports.Count()>0;
+    }
+  }
+
   public class PortCheckCompletedEventArgs
     : EventArgs
   {
@@ -23,6 +65,20 @@ namespace PeerCastStation.UI
   }
   public delegate void PortCheckCompletedEventHandler(object sender, PortCheckCompletedEventArgs args);
 
+  public class PortCheckResult
+  {
+    public bool     Success     { get; private set; }
+    public int[]    Ports       { get; private set; }
+    public TimeSpan ElapsedTime { get; private set; }
+
+    public PortCheckResult(bool success, int[] ports, TimeSpan elapsed)
+    {
+      this.Success     = success;
+      this.Ports       = ports;
+      this.ElapsedTime = elapsed;
+    }
+  }
+
   public class PCPPortChecker
   {
     public Guid  InstanceId { get; private set; }
@@ -33,6 +89,46 @@ namespace PeerCastStation.UI
       this.InstanceId = instance_id;
       this.Target = target_uri;
       this.Ports = ports.ToArray();
+    }
+
+    public async Task<PortCheckResult> RunTaskAsync()
+    {
+      var client = new WebClient();
+      var data   = new JObject();
+      data["instanceId"] = InstanceId.ToString("N");
+      data["ports"] = new JArray(Ports);
+      var succeeded = false;
+      var stopwatch = new System.Diagnostics.Stopwatch();
+      string response_body = null;
+      try {
+        stopwatch.Start();
+        var body = System.Text.Encoding.UTF8.GetBytes(data.ToString());
+        response_body = System.Text.Encoding.UTF8.GetString(
+          await client.UploadDataTaskAsync(Target, body)
+        );
+        stopwatch.Stop();
+        succeeded = true;
+        var response = JToken.Parse(response_body);
+        var response_ports = response["ports"].Select(token => (int)token);
+        return new PortCheckResult(
+            succeeded,
+            response_ports.ToArray(),
+            stopwatch.Elapsed);
+      }
+      catch (WebException) {
+        succeeded = false;
+        return new PortCheckResult(
+            succeeded,
+            null,
+            stopwatch.Elapsed);
+      }
+      catch (Newtonsoft.Json.JsonReaderException) {
+        succeeded = false;
+        return new PortCheckResult(
+            succeeded,
+            null,
+            stopwatch.Elapsed);
+      }
     }
 
     public void RunAsync()

--- a/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingControl.xaml.cs
+++ b/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingControl.xaml.cs
@@ -40,7 +40,7 @@ namespace PeerCastStation.WPF.CoreSettings
 
     private void PortCheckButton_Click(object sender, RoutedEventArgs args)
     {
-      ((SettingViewModel)this.DataContext).PortCheck();
+      ((SettingViewModel)this.DataContext).CheckPort();
     }
 
   }

--- a/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingViewModel.cs
+++ b/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingViewModel.cs
@@ -753,23 +753,6 @@ namespace PeerCastStation.WPF.CoreSettings
       });
     }
 
-    void checker_PortCheckCompleted(object sender, UI.PortCheckCompletedEventArgs args)
-    {
-      if (args.Success) {
-        var status = PortCheckStatus.Closed;
-        foreach (var port in ports) {
-          port.IsOpen = args.Ports.Contains(port.Port);
-          if (port.IsOpen.HasValue && port.IsOpen.Value) {
-            status = PortCheckStatus.Opened;
-          }
-        }
-        PortCheckStatus = status;
-      }
-      else {
-        PortCheckStatus = PortCheckStatus.Failed;
-      }
-    }
-
     protected override void OnPropertyChanged(string propertyName)
     {
       switch (propertyName) {


### PR DESCRIPTION
起動時や設定画面で自動的にポートチェックを行うようにする。

起動時にポート開放状態は不明で、トラッカーやYPに接続しに行った時点で初めてポート開放確認をしていたが、起動時にポート開放状態が分かっていた方が便利なので、起動時にポート開放確認を行うようにした。
また、設定画面を開いた時もポート開放確認が状態不明だったので、設定画面を開いた時や設定変更時にポート開放確認を自動的に行って、UIだけでなく本体のポート開放状態にも反映させるようにした。
ポート開放確認を頻繁に行うようにはなるのでサーバの負荷が心配だが、一旦設定したあとは起動時のみの確認になるので問題ないと思われる。