### PR TITLE
配信時にコンテントタイプの選択が不要なプロトコルの場合は選択できないようにする

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/Core.cs
+++ b/PeerCastStation/PeerCastStation.Core/Core.cs
@@ -475,6 +475,10 @@ namespace PeerCastStation.Core
     /// </summary>
     SourceStreamType Type { get; }
     /// <summary>
+    /// ContentReaderの指定が必要かどうかを取得します
+    /// </summary>
+    bool IsContentReaderRequired { get; }
+    /// <summary>
     /// 配信時に使われるURIのデフォルト値を取得します
     /// </summary>
     Uri DefaultUri { get; }

--- a/PeerCastStation/PeerCastStation.Core/SourceStreamBase.cs
+++ b/PeerCastStation/PeerCastStation.Core/SourceStreamBase.cs
@@ -33,6 +33,7 @@ namespace PeerCastStation.Core
     public abstract string           Scheme { get; }
     public abstract SourceStreamType Type { get; }
     public abstract Uri              DefaultUri { get; }
+    public abstract bool             IsContentReaderRequired { get; }
     public virtual ISourceStream Create(Channel channel, Uri tracker)
     {
       throw new NotImplementedException();

--- a/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPSourceStream.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPSourceStream.cs
@@ -33,6 +33,10 @@ namespace PeerCastStation.FLV.RTMP
       get { return new Uri("rtmp://localhost/live/livestream"); }
     }
 
+    public override bool IsContentReaderRequired {
+      get { return false; }
+    }
+
     public override ISourceStream Create(Channel channel, Uri source, IContentReader reader)
     {
       return new RTMPSourceStream(PeerCast, channel, source);

--- a/PeerCastStation/PeerCastStation.HTTP/HTTPPushSourceStream.cs
+++ b/PeerCastStation/PeerCastStation.HTTP/HTTPPushSourceStream.cs
@@ -33,6 +33,10 @@ namespace PeerCastStation.HTTP
       get { return new Uri("http://localhost:8080/"); }
     }
 
+    public override bool IsContentReaderRequired {
+      get { return true; }
+    }
+
     public override ISourceStream Create(Channel channel, Uri source, IContentReader reader)
     {
       return new HTTPPushSourceStream(PeerCast, channel, source, reader);
@@ -237,6 +241,7 @@ namespace PeerCastStation.HTTP
       });
       if (request==null) new HTTPError(HttpStatusCode.BadRequest);
       if (request.Method!="POST") new HTTPError(HttpStatusCode.MethodNotAllowed);
+      Logger.Debug("POST requested");
 
       string encodings;
       if (request.Headers.TryGetValue("TRANSFER-ENCODING", out encodings)) {
@@ -249,9 +254,12 @@ namespace PeerCastStation.HTTP
           new HTTPError(HttpStatusCode.NotImplemented);
         }
         chunked = true;
+        Logger.Debug("chunked encoding");
       }
 
-      Logger.Debug("Handshake succeeded");
+      if (request.Headers.ContainsKey("CONTENT-TYPE")) {
+        Logger.Debug("Content-Type: {0}", request.Headers["CONTENT-TYPE"]);
+      }
       return true;
     }
 

--- a/PeerCastStation/PeerCastStation.HTTP/HTTPSourceStream.cs
+++ b/PeerCastStation/PeerCastStation.HTTP/HTTPSourceStream.cs
@@ -93,6 +93,9 @@ namespace PeerCastStation.HTTP
     public override Uri DefaultUri {
       get { return new Uri("http://localhost:8080/"); }
     }
+    public override bool IsContentReaderRequired {
+      get { return true; }
+    }
 
     public override ISourceStream Create(Channel channel, Uri source, IContentReader reader)
     {

--- a/PeerCastStation/PeerCastStation.PCP/PCPSourceStream.cs
+++ b/PeerCastStation/PeerCastStation.PCP/PCPSourceStream.cs
@@ -45,6 +45,10 @@ namespace PeerCastStation.PCP
       get { return null; }
     }
 
+    public override bool IsContentReaderRequired {
+      get { return false; }
+    }
+
     public override ISourceStream Create(Channel channel, Uri tracker)
     {
       return new PCPSourceStream(PeerCast, channel, tracker);

--- a/PeerCastStation/PeerCastStation.UI.HTTP/APIHost.cs
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/APIHost.cs
@@ -645,6 +645,7 @@ namespace PeerCastStation.UI.HTTP
           res["scheme"]     = sstream.Scheme;
           res["type"]       = (int)sstream.Type;
           res["defaultUri"] = sstream.DefaultUri!=null ? sstream.DefaultUri.ToString() : "";
+          res["isContentReaderRequired"] = sstream.IsContentReaderRequired;
           return res;
         }).ToArray());
       }

--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/js/relays.js
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/js/relays.js
@@ -173,6 +173,11 @@ var BroadcastDialog = new function() {
     }
   });
 
+  self.contentTypeVisibility = ko.computed(function () {
+    var source_stream = self.sourceStream();
+    return source_stream && source_stream.isContentReaderRequired;
+  });
+
   self.yellowPages = ko.observableArray([
     {
       yellowPageId: null,

--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/relays.html
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/relays.html
@@ -269,7 +269,7 @@
           <tr><th>ソース</th>            <td><select data-bind="options:sourceStreams, optionsText: 'desc', value:sourceStream"></select></td></tr>
           <tr><th>ストリームURL</th>      <td><input type="text" name="sourceUrl"       data-bind="value:source          "></td></tr>
           <tr><th>ビットレート</th>       <td><input type="text" name="infoBitrate"     data-bind="value:infoBitrate     "></td></tr>
-          <tr><th>ストリームタイプ</th>   <td><select data-bind="options:contentTypes, optionsText: 'desc', value:contentType"></select></td></tr>
+          <tr data-bind="visible:contentTypeVisibility"><th>ストリームタイプ</th>   <td><select data-bind="options:contentTypes, optionsText: 'desc', value:contentType"></select></td></tr>
           <tr><th>掲載YP</th>            <td><select data-bind="options: yellowPages, optionsText: 'name', value:yellowPage"></select></td></tr>
           <tr><th>チャンネル名</th>       <td><input type="text" name="infoName"        data-bind="value:infoName        "></td></tr>
           <tr><th>ジャンル</th>           <td><input type="text" name="infoGenre"       data-bind="value:infoGenre       "></td></tr>

--- a/PeerCastStation/PeerCastStation.WPF/ChannelLists/Dialogs/BroadcastViewModel.cs
+++ b/PeerCastStation/PeerCastStation.WPF/ChannelLists/Dialogs/BroadcastViewModel.cs
@@ -21,6 +21,7 @@ using PeerCastStation.Core;
 using PeerCastStation.WPF.ChannelLists.ChannelInfos;
 using PeerCastStation.WPF.Commons;
 using PeerCastStation.WPF.CoreSettings;
+using System.Windows;
 
 namespace PeerCastStation.WPF.ChannelLists.Dialogs
 {
@@ -81,8 +82,18 @@ namespace PeerCastStation.WPF.ChannelLists.Dialogs
             value!=null &&
             value.DefaultUri!=null) {
           StreamUrl = value.DefaultUri.ToString();
+          OnPropertyChanged("IsContentReaderRequired");
+          OnPropertyChanged("ContentTypeVisibility");
         }
       }
+    }
+
+    public Visibility ContentTypeVisibility {
+      get { return IsContentReaderRequired ? Visibility.Visible : Visibility.Collapsed; }
+    }
+
+    public bool IsContentReaderRequired {
+      get { return selectedSourceStream!=null && selectedSourceStream.IsContentReaderRequired; }
     }
 
     private string streamUrl = "";

--- a/PeerCastStation/PeerCastStation.WPF/ChannelLists/Dialogs/BroadcastWindow.xaml
+++ b/PeerCastStation/PeerCastStation.WPF/ChannelLists/Dialogs/BroadcastWindow.xaml
@@ -119,10 +119,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. -->
           </ComboBox>
           <TextBlock Grid.Column="1" Text="kbps" VerticalAlignment="Center"/>
         </Grid>
-        <Label    Grid.Column="0" Grid.Row="3" Content="タイプ:"/>
+        <Label    Grid.Column="0" Grid.Row="3" Content="タイプ:"
+                  Visibility="{Binding ContentTypeVisibility}"/>
         <ComboBox Grid.Column="1" Grid.Row="3"
                   ItemsSource="{Binding ContentTypes}"
                   SelectedItem="{Binding ContentType}"
+                  Visibility="{Binding ContentTypeVisibility}"
                   DisplayMemberPath="Name"/>
         <Label    Grid.Column="0" Grid.Row="4" Content="掲載YP:"/>
         <ComboBox Grid.Column="1" Grid.Row="4"


### PR DESCRIPTION
RTMPなんかのコンテントタイプの選択が不要なプロトコルで配信する場合は、選択肢自体を非表示にして選べないようにする。
HTTPの場合は逆に選択が必須となるが、プロトコル毎にコンテントタイプ指定の要・不要が分かりづらいので、不要なプロトコルの場合は選べないようにした。