### PR TITLE
アップデートページの誤表記を修正

### DIFF
--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/js/update.js
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/js/update.js
@@ -33,6 +33,9 @@ var UpdateViewModel = new function() {
         case "installer":
           title = "インストーラをダウンロード";
           break;
+        case "serviceinstaller":
+          title = "サービス版インストーラをダウンロード";
+          break;
         }
         self.enclosures.push({
           title: title,


### PR DESCRIPTION
アップデートページにある３つのダウンロードボタンがそれぞれ
「ZIPをダウンロード」「インストーラをダウンロード」「ZIP」
と表示されていたのを
「ZIPをダウンロード」「インストーラをダウンロード」「サービス版インストーラをダウンロード」
と表示される様に修正しました。