### PR TITLE
RTMPハンドシェイク時に常にハンドシェイクが失敗したことになっていたのを修正。

### DIFF
--- a/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPSourceStream.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPSourceStream.cs
@@ -268,7 +268,7 @@ namespace PeerCastStation.FLV.RTMP
       using (var reader=new RTMPBinaryReader(new MemoryStream(Recv(1536)))) {
         reader.ReadInt32();
         reader.ReadInt32();
-        if (!s1vec.Equals(reader.ReadBytes(1528))) {
+        if (!s1vec.SequenceEqual(reader.ReadBytes(1528))) {
           Logger.Debug("Handshake failed");
           return false;
         }


### PR DESCRIPTION
Equals メソッドはオブジェクトの同一性しかみてくれず、ランダムバイト列の比較が行なわれていなかったようです。