### PR TITLE
RTMPソースストリームの接続にタイムアウトを設定

### DIFF
--- a/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPSourceStream.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPSourceStream.cs
@@ -183,7 +183,10 @@ namespace PeerCastStation.FLV.RTMP
 			}
 			if (client!=null) {
 				this.client = client;
-				return new StreamConnection(client.GetStream(), client.GetStream());
+				var connection = new StreamConnection(client.GetStream(), client.GetStream());
+				connection.ReceiveTimeout = 10000;
+				connection.SendTimeout = 8000;
+				return connection;
 			}
 			else {
 				return null;


### PR DESCRIPTION
VPSで動くペカステへリモートからRTMP接続で配信する場合、回線が切断されるとエンコーダーとの接続が残り、手動でソース接続をリセットするか、チャンネルを停止するまでYPにチャンネルが見られない状態で載りつづけます。

接続が死んでいることが検知できるよう、受信10秒、送信8秒のタイムアウトを設定しました。