### PR TITLE
HTTP Dummy 出力ストリームがマッチしなくなっていたのを修正。

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/OutputListener.cs
+++ b/PeerCastStation/PeerCastStation.Core/OutputListener.cs
@@ -295,7 +295,7 @@ namespace PeerCastStation.Core
             offset += len;
             var header_ary = header.Take(offset).ToArray();
             foreach (var factory in output_factories) {
-              if (!acinfo.Accepts.HasFlag(factory.OutputStreamType)) continue;
+              if ((acinfo.Accepts & factory.OutputStreamType) == 0) continue;
               var channel_id = factory.ParseChannelID(header_ary);
               if (channel_id.HasValue) {
                 return factory.Create(


### PR DESCRIPTION
「操作」が許可されておらず、OWIN Host 出力ストリームがマッチしなかった場合に、HTTPリクエストの受け皿になるHTTP Dummy がマッチしないために、以前は404を返す挙動だったのが、3秒間のタイムアウトになるまでデータを待った後、切断するようになっていました。