### PR TITLE
LAN/WANの接続許可設定が変更された時に、AccessControlInfoをそれに応じて更新するようにしました。

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/OutputListener.cs
+++ b/PeerCastStation/PeerCastStation.Core/OutputListener.cs
@@ -54,7 +54,10 @@ namespace PeerCastStation.Core
     /// </summary>
     public OutputStreamType LocalOutputAccepts  {
       get { return localOutputAccepts;  }
-      set { localOutputAccepts = value; }
+      set {
+        localOutputAccepts = value;
+        UpdateLocalAccessControlInfo();
+      }
     }
     private OutputStreamType localOutputAccepts;
 
@@ -83,6 +86,7 @@ namespace PeerCastStation.Core
           else                                     PeerCast.OnListenPortClosed();
         }
         globalOutputAccepts = value;
+        UpdateGlobalAccessControlInfo();
       }
     }
     private OutputStreamType globalOutputAccepts;


### PR DESCRIPTION
パスワード認証の設定が変更されたとき以外は、接続許可の設定が実際に反映されていませんでした。

[WAN操作の設定がOFFでもHTML UIが見れる場合がある](https://github.com/kumaryu/peercaststation/issues/265)の原因の可能性があると思います。