### PR TITLE
ホスト情報の uphp を int ではなく byte として読み取ろうとしていたため、読めていなかったのを修正。

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/AtomCollectionExtensions.cs
+++ b/PeerCastStation/PeerCastStation.Core/AtomCollectionExtensions.cs
@@ -592,9 +592,9 @@ namespace PeerCastStation.Core
       }
     }
 
-    public static byte? GetHostUphostHops(this IAtomCollection collection)
+    public static int? GetHostUphostHops(this IAtomCollection collection)
     {
-      return GetByteFrom(collection, Atom.PCP_HOST_UPHOST_HOPS);
+      return GetIntFrom(collection, Atom.PCP_HOST_UPHOST_HOPS);
     }
 
     public static int? GetQuit(this IAtomCollection collection)


### PR DESCRIPTION
トラッカーに接続したときに受け取るホスト情報は、uphp は存在しないか 4 バイトかになっているようでした。