### PR TITLE
GetEnvValueが渡されたキー値を使うようにしました。

### DIFF
--- a/PeerCastStation/PeerCastStation.UI.HTTP/OWINHost.cs
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/OWINHost.cs
@@ -118,7 +118,7 @@ namespace PeerCastStation.UI.HTTP
     T GetEnvValue<T>(IDictionary<string, object> env, string key, T default_value)
     {
       object value;
-      if (env.TryGetValue("owin.ResponseStatusCode", out value) && value is T) {
+      if (env.TryGetValue(key, out value) && value is T) {
         return (T)value;
       }
       else {


### PR DESCRIPTION
OWINEnvのResponseProtocolプロパティに値を設定しても、応答時にデフォルト値が使われてしまうようでした。