### PR TITLE
RTMPソース接続の待機に失敗した場合のリトライを間隔を空けてするようにした。

### DIFF
--- a/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPSourceStream.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPSourceStream.cs
@@ -128,6 +128,7 @@ namespace PeerCastStation.FLV.RTMP
       TcpClient client = null;
       var bind_addr = GetBindAddresses(source);
       if (bind_addr.Count()==0) {
+        this.state = ConnectionState.Error;
         throw new BindErrorException(String.Format("Cannot resolve bind address: {0}", source.DnsSafeHost));
       }
       var listeners = bind_addr.Select(addr => new TcpListener(addr)).ToArray();
@@ -144,6 +145,7 @@ namespace PeerCastStation.FLV.RTMP
         }
       }
       catch (SocketException) {
+        this.state = ConnectionState.Error;
         throw new BindErrorException(String.Format("Cannot bind address: {0}", bind_addr));
       }
       finally {
@@ -824,7 +826,7 @@ namespace PeerCastStation.FLV.RTMP
         Stop(reason);
         break;
       default:
-        Reconnect();
+        Task.Delay(3000).ContinueWith(prev => Reconnect());
         break;
       }
     }


### PR DESCRIPTION
ソースURLのIPアドレスが自ホストのものと異なる、既にポートが使われている等の理由でRTMPソース接続の待機ができない場合、リトライがディレイなしに行なわれるのでCPUやソケットのリソースを消費していたのを修正しました。

また、エラー後のディレイの間チャンネルの状態表示が Error になるようにソース接続の状態を変更するようにしました。