### PR TITLE
JSON RPCで取得できるConnectionInfoにセッションIDを追加する

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/ConnectionInfoBuilder.cs
+++ b/PeerCastStation/PeerCastStation.Core/ConnectionInfoBuilder.cs
@@ -31,6 +31,7 @@ namespace PeerCastStation.Core
       this.RemoteName       = other.RemoteName;
       this.RemoteEndPoint   = other.RemoteEndPoint;
       this.RemoteHostStatus = other.RemoteHostStatus;
+      this.RemoteSessionID  = other.RemoteSessionID;
       this.ContentPosition  = other.ContentPosition;
       this.RecvRate         = other.RecvRate;
       this.SendRate         = other.SendRate;
@@ -48,6 +49,7 @@ namespace PeerCastStation.Core
         this.RemoteName,
         this.RemoteEndPoint,
         this.RemoteHostStatus,
+        this.RemoteSessionID,
         this.ContentPosition,
         this.RecvRate,
         this.SendRate,

--- a/PeerCastStation/PeerCastStation.Core/ConnectionInfoBuilder.cs
+++ b/PeerCastStation/PeerCastStation.Core/ConnectionInfoBuilder.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Net;
+
+namespace PeerCastStation.Core
+{
+  public class ConnectionInfoBuilder
+  {
+    public string     ProtocolName    { get; set; } = "";
+    public ConnectionType   Type      { get; set; } = ConnectionType.None;
+    public ConnectionStatus Status    { get; set; } = ConnectionStatus.Idle;
+    public IPEndPoint RemoteEndPoint  { get; set; } = null;
+    public RemoteHostStatus RemoteHostStatus { get; set; } = RemoteHostStatus.None;
+    public Guid?      RemoteSessionID { get; set; } = null;
+    public long?      ContentPosition { get; set; } = null;
+    public float?     RecvRate        { get; set; } = null;
+    public float?     SendRate        { get; set; } = null;
+    public int?       LocalRelays     { get; set; } = null;
+    public int?       LocalDirects    { get; set; } = null;
+    public string     AgentName       { get; set; } = null;
+    public string     RemoteName      { get; set; } = null;
+
+    public ConnectionInfoBuilder()
+    {
+    }
+
+    public ConnectionInfoBuilder(ConnectionInfo other)
+    {
+      this.ProtocolName     = other.ProtocolName;
+      this.Type             = other.Type;
+      this.Status           = other.Status;
+      this.RemoteName       = other.RemoteName;
+      this.RemoteEndPoint   = other.RemoteEndPoint;
+      this.RemoteHostStatus = other.RemoteHostStatus;
+      this.ContentPosition  = other.ContentPosition;
+      this.RecvRate         = other.RecvRate;
+      this.SendRate         = other.SendRate;
+      this.LocalRelays      = other.LocalRelays;
+      this.LocalDirects     = other.LocalDirects;
+      this.AgentName        = other.AgentName;
+    }
+
+    public ConnectionInfo Build()
+    {
+      return new ConnectionInfo(
+        this.ProtocolName,
+        this.Type,
+        this.Status,
+        this.RemoteName,
+        this.RemoteEndPoint,
+        this.RemoteHostStatus,
+        this.ContentPosition,
+        this.RecvRate,
+        this.SendRate,
+        this.LocalRelays,
+        this.LocalDirects,
+        this.AgentName);
+    }
+
+  }
+
+}

--- a/PeerCastStation/PeerCastStation.Core/Core.cs
+++ b/PeerCastStation/PeerCastStation.Core/Core.cs
@@ -301,6 +301,7 @@ namespace PeerCastStation.Core
     public ConnectionStatus Status    { get; private set; }
     public IPEndPoint RemoteEndPoint  { get; private set; }
     public RemoteHostStatus RemoteHostStatus { get; private set; }
+    public Guid?      RemoteSessionID { get; private set; }
     public long?      ContentPosition { get; private set; }
     public float?     RecvRate        { get; private set; }
     public float?     SendRate        { get; private set; }
@@ -315,6 +316,7 @@ namespace PeerCastStation.Core
       string           remote_name,
       IPEndPoint       remote_endpoint,
       RemoteHostStatus remote_host_status,
+      Guid?            remote_session_id,
       long?      content_position,
       float?     recv_rate,
       float?     send_rate,
@@ -328,6 +330,7 @@ namespace PeerCastStation.Core
       RemoteName       = remote_name;
       RemoteEndPoint   = remote_endpoint;
       RemoteHostStatus = remote_host_status;
+      RemoteSessionID  = remote_session_id;
       ContentPosition  = content_position;
       RecvRate         = recv_rate;
       SendRate         = send_rate;

--- a/PeerCastStation/PeerCastStation.Core/PeerCastStation.Core.csproj
+++ b/PeerCastStation/PeerCastStation.Core/PeerCastStation.Core.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Channel.cs" />
     <Compile Include="ChannelCleaner.cs" />
     <Compile Include="ChannelInfo.cs" />
+    <Compile Include="ConnectionInfoBuilder.cs" />
     <Compile Include="Content.cs" />
     <Compile Include="ContentSink.cs" />
     <Compile Include="Core.cs" />

--- a/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPOutputStream.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPOutputStream.cs
@@ -129,17 +129,18 @@ namespace PeerCastStation.FLV.RTMP
 
 		public ConnectionInfo GetConnectionInfo()
 		{
-			return new ConnectionInfo(
-				"RTMP Output",
-				ConnectionType.Direct,
-				ConnectionStatus.Connected,
-				remoteEndPoint.ToString(),
-				remoteEndPoint as System.Net.IPEndPoint,
-				RemoteHostStatus.Receiving,
-				connection.ContentPosition,
-				(float)this.inputStream.ReadRate, (float)this.outputStream.WriteRate,
-				null, null,
-				connection.ClientName);
+      return new ConnectionInfoBuilder {
+        ProtocolName     = "RTMP Output",
+        Type             = ConnectionType.Direct,
+        Status           = ConnectionStatus.Connected,
+        RemoteName       = remoteEndPoint.ToString(),
+        RemoteEndPoint   = remoteEndPoint as System.Net.IPEndPoint,
+        RemoteHostStatus = RemoteHostStatus.Receiving,
+        ContentPosition  = connection.ContentPosition,
+        RecvRate         = (float)this.inputStream.ReadRate,
+        SendRate         = (float)this.outputStream.WriteRate,
+        AgentName        = connection.ClientName
+      }.Build();
 		}
 
 		public OutputStreamType OutputStreamType {

--- a/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPSourceStream.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPSourceStream.cs
@@ -80,19 +80,18 @@ namespace PeerCastStation.FLV.RTMP
       if (connection!=null) {
         endpoint = connection.RemoteEndPoint;
       }
-      return new ConnectionInfo(
-        "RTMP Source",
-        ConnectionType.Source,
-        status,
-        SourceUri.ToString(),
-        endpoint,
-        (endpoint!=null && endpoint.Address.IsSiteLocal()) ? RemoteHostStatus.Local : RemoteHostStatus.None,
-        flvBuffer.Position,
-        RecvRate,
-        SendRate,
-        null,
-        null,
-        clientName);
+      return new ConnectionInfoBuilder {
+        ProtocolName     = "RTMP Source",
+        Type             = ConnectionType.Source,
+        Status           = status,
+        RemoteName       = SourceUri.ToString(),
+        RemoteEndPoint   = endpoint,
+        RemoteHostStatus = (endpoint!=null && endpoint.Address.IsSiteLocal()) ? RemoteHostStatus.Local : RemoteHostStatus.None,
+        ContentPosition  = flvBuffer.Position,
+        RecvRate         = RecvRate,
+        SendRate         = SendRate,
+        AgentName        = clientName,
+      }.Build();
     }
 
     private enum ConnectionState {
@@ -801,19 +800,15 @@ namespace PeerCastStation.FLV.RTMP
         }
         IPEndPoint endpoint = null;
         string client_name = "";
-        return new ConnectionInfo(
-          "RTMP Source",
-          ConnectionType.Source,
-          status,
-          SourceUri.ToString(),
-          endpoint,
-          RemoteHostStatus.None,
-          null,
-          null,
-          null,
-          null,
-          null,
-          client_name);
+        return new ConnectionInfoBuilder {
+          ProtocolName     = "RTMP Source",
+          Type             = ConnectionType.Source,
+          Status           = status,
+          RemoteName       = SourceUri.ToString(),
+          RemoteEndPoint   = endpoint,
+          RemoteHostStatus = RemoteHostStatus.None,
+          AgentName        = client_name,
+        }.Build();
       }
     }
 

--- a/PeerCastStation/PeerCastStation.HTTP/HTTPDummyOutputStream.cs
+++ b/PeerCastStation/PeerCastStation.HTTP/HTTPDummyOutputStream.cs
@@ -114,19 +114,17 @@ namespace PeerCastStation.HTTP
 
     public override ConnectionInfo GetConnectionInfo()
     {
-      return new ConnectionInfo(
-        "No Protocol Matched",
-        ConnectionType.Metadata,
-        ConnectionStatus.Connected,
-        RemoteEndPoint.ToString(),
-        (IPEndPoint)RemoteEndPoint,
-        IsLocal ? RemoteHostStatus.Local : RemoteHostStatus.None,
-        null,
-        Connection.ReadRate,
-        Connection.WriteRate,
-        null,
-        null,
-        request.Headers["USER-AGENT"]);
+      return new ConnectionInfoBuilder {
+        ProtocolName     = "No Protocol Matched",
+        Type             = ConnectionType.Metadata,
+        Status           = ConnectionStatus.Connected,
+        RemoteName       = RemoteEndPoint.ToString(),
+        RemoteEndPoint   = (IPEndPoint)RemoteEndPoint,
+        RemoteHostStatus = IsLocal ? RemoteHostStatus.Local : RemoteHostStatus.None,
+        RecvRate         = Connection.ReadRate,
+        SendRate         = Connection.WriteRate,
+        AgentName        = request.Headers["USER-AGENT"],
+      }.Build();
     }
   }
 

--- a/PeerCastStation/PeerCastStation.HTTP/HTTPOutputStream.cs
+++ b/PeerCastStation/PeerCastStation.HTTP/HTTPOutputStream.cs
@@ -467,19 +467,18 @@ namespace PeerCastStation.HTTP
       if (request.Headers.ContainsKey("USER-AGENT")) {
         user_agent = request.Headers["USER-AGENT"];
       }
-      return new ConnectionInfo(
-        "HTTP Direct",
-        ConnectionType.Direct,
-        status,
-        RemoteEndPoint.ToString(),
-        (IPEndPoint)RemoteEndPoint,
-        IsLocal ? RemoteHostStatus.Local : RemoteHostStatus.None,
-        lastPacket!=null ? lastPacket.Position : 0,
-        Connection.ReadRate,
-        Connection.WriteRate,
-        null,
-        null,
-        user_agent);
+      return new ConnectionInfoBuilder() {
+        ProtocolName     = "HTTP Direct",
+        Type             = ConnectionType.Direct,
+        Status           = status,
+        RemoteName       = RemoteEndPoint.ToString(),
+        RemoteEndPoint   = (IPEndPoint)RemoteEndPoint,
+        RemoteHostStatus = IsLocal ? RemoteHostStatus.Local : RemoteHostStatus.None,
+        ContentPosition  = lastPacket!=null ? lastPacket.Position : 0,
+        RecvRate         = Connection.ReadRate,
+        SendRate         = Connection.WriteRate,
+        AgentName        = user_agent,
+      }.Build();
     }
 
     public async Task WaitChannelReceived()

--- a/PeerCastStation/PeerCastStation.HTTP/HTTPPushSourceStream.cs
+++ b/PeerCastStation/PeerCastStation.HTTP/HTTPPushSourceStream.cs
@@ -81,19 +81,18 @@ namespace PeerCastStation.HTTP
       if (this.connection?.Client?.Connected ?? false) {
         endpoint = (IPEndPoint)this.connection.Client.Client.RemoteEndPoint;
       }
-      return new ConnectionInfo(
-        "HTTP Push Source",
-        ConnectionType.Source,
-        status,
-        SourceUri.ToString(),
-        endpoint,
-        (endpoint!=null && endpoint.Address.IsSiteLocal()) ? RemoteHostStatus.Local : RemoteHostStatus.None,
-        contentSink.LastContent?.Position ?? 0,
-        RecvRate,
-        SendRate,
-        null,
-        null,
-        clientName);
+      return new ConnectionInfoBuilder {
+        ProtocolName     = "HTTP Push Source",
+        Type             = ConnectionType.Source,
+        Status           = status,
+        RemoteName       = SourceUri.ToString(),
+        RemoteEndPoint   = endpoint,
+        RemoteHostStatus = (endpoint!=null && endpoint.Address.IsSiteLocal()) ? RemoteHostStatus.Local : RemoteHostStatus.None,
+        ContentPosition  = contentSink.LastContent?.Position ?? 0,
+        RecvRate         = RecvRate,
+        SendRate         = SendRate,
+        AgentName        = clientName,
+      }.Build();
     }
 
     private enum ConnectionState {
@@ -280,19 +279,16 @@ namespace PeerCastStation.HTTP
         }
         IPEndPoint endpoint = null;
         string client_name = "";
-        return new ConnectionInfo(
-          "RTMP Source",
-          ConnectionType.Source,
-          status,
-          SourceUri.ToString(),
-          endpoint,
-          RemoteHostStatus.None,
-          null,
-          null,
-          null,
-          null,
-          null,
-          client_name);
+
+        return new ConnectionInfoBuilder {
+          ProtocolName     = "RTMP Source",
+          Type             = ConnectionType.Source,
+          Status           = status,
+          RemoteName       = SourceUri.ToString(),
+          RemoteEndPoint   = endpoint,
+          RemoteHostStatus = RemoteHostStatus.None,
+          AgentName        = client_name,
+        }.Build();
       }
     }
 

--- a/PeerCastStation/PeerCastStation.HTTP/HTTPSourceStream.cs
+++ b/PeerCastStation/PeerCastStation.HTTP/HTTPSourceStream.cs
@@ -180,19 +180,18 @@ namespace PeerCastStation.HTTP
       if (response==null || !response.Headers.TryGetValue("SERVER", out server_name)) {
         server_name = "";
       }
-      return new ConnectionInfo(
-        "HTTP Source",
-        ConnectionType.Source,
-        Status,
-        SourceUri.ToString(),
-        endpoint,
-        (endpoint!=null && endpoint.Address.IsSiteLocal()) ? RemoteHostStatus.Local : RemoteHostStatus.None,
-        contentSink.LastContent?.Position ?? 0,
-        RecvRate,
-        SendRate,
-        null,
-        null,
-        server_name);
+      return new ConnectionInfoBuilder {
+        ProtocolName     = "HTTP Source",
+        Type             = ConnectionType.Source,
+        Status           = Status,
+        RemoteName       = SourceUri.ToString(),
+        RemoteEndPoint   = endpoint,
+        RemoteHostStatus = (endpoint!=null && endpoint.Address.IsSiteLocal()) ? RemoteHostStatus.Local : RemoteHostStatus.None,
+        ContentPosition  = contentSink.LastContent?.Position ?? 0,
+        RecvRate         = RecvRate,
+        SendRate         = SendRate,
+        AgentName        = server_name,
+      }.Build();
     }
 
   }
@@ -224,19 +223,15 @@ namespace PeerCastStation.HTTP
         }
         IPEndPoint endpoint = null;
         string server_name = "";
-        return new ConnectionInfo(
-          "HTTP Source",
-          ConnectionType.Source,
-          status,
-          SourceUri.ToString(),
-          endpoint,
-          RemoteHostStatus.None,
-          null,
-          null,
-          null,
-          null,
-          null,
-          server_name);
+        return new ConnectionInfoBuilder {
+          ProtocolName     = "HTTP Source",
+          Type             = ConnectionType.Source,
+          Status           = status,
+          RemoteName       = SourceUri.ToString(),
+          RemoteEndPoint   = endpoint,
+          RemoteHostStatus = RemoteHostStatus.None,
+          AgentName        = server_name,
+        }.Build();
       }
     }
 

--- a/PeerCastStation/PeerCastStation.PCP/PCPOutputStream.cs
+++ b/PeerCastStation/PeerCastStation.PCP/PCPOutputStream.cs
@@ -246,19 +246,20 @@ namespace PeerCastStation.PCP
         relay_count  = Downhost.RelayCount;
         direct_count = Downhost.DirectCount;
       }
-      return new ConnectionInfo(
-        "PCP Relay",
-        ConnectionType.Relay,
-        status,
-        RemoteEndPoint.ToString(),
-        (IPEndPoint)RemoteEndPoint,
-        host_status,
-        lastPosition,
-        Connection.ReadRate,
-        Connection.WriteRate,
-        relay_count,
-        direct_count,
-        this.UserAgent ?? "");
+      return new ConnectionInfoBuilder {
+        ProtocolName     = "PCP Relay",
+        Type             = ConnectionType.Relay,
+        Status           = status,
+        RemoteName       = RemoteEndPoint.ToString(),
+        RemoteEndPoint   = (IPEndPoint)RemoteEndPoint,
+        RemoteHostStatus = host_status,
+        ContentPosition  = lastPosition,
+        RecvRate         = Connection.ReadRate,
+        SendRate         = Connection.WriteRate,
+        LocalRelays      = relay_count,
+        LocalDirects     = direct_count,
+        AgentName        = this.UserAgent ?? "",
+      }.Build();
     }
 
     private RelayRequest relayRequest;

--- a/PeerCastStation/PeerCastStation.PCP/PCPOutputStream.cs
+++ b/PeerCastStation/PeerCastStation.PCP/PCPOutputStream.cs
@@ -253,6 +253,7 @@ namespace PeerCastStation.PCP
         RemoteName       = RemoteEndPoint.ToString(),
         RemoteEndPoint   = (IPEndPoint)RemoteEndPoint,
         RemoteHostStatus = host_status,
+        RemoteSessionID  = Downhost?.SessionID,
         ContentPosition  = lastPosition,
         RecvRate         = Connection.ReadRate,
         SendRate         = Connection.WriteRate,

--- a/PeerCastStation/PeerCastStation.PCP/PCPPongOutputStream.cs
+++ b/PeerCastStation/PeerCastStation.PCP/PCPPongOutputStream.cs
@@ -143,19 +143,16 @@ namespace PeerCastStation.PCP
       if (IsStopped) {
         status = HasError ? ConnectionStatus.Error : ConnectionStatus.Idle;
       }
-      return new ConnectionInfo(
-        "PCP Pong",
-        ConnectionType.Metadata,
-        status,
-        RemoteEndPoint.ToString(),
-        (IPEndPoint)RemoteEndPoint,
-        IsLocal ? RemoteHostStatus.Local : RemoteHostStatus.None,
-        null,
-        Connection.ReadRate,
-        Connection.WriteRate,
-        null,
-        null,
-        null);
+      return new ConnectionInfoBuilder {
+        ProtocolName     = "PCP Pong",
+        Type             = ConnectionType.Metadata,
+        Status           = status,
+        RemoteName       = RemoteEndPoint.ToString(),
+        RemoteEndPoint   = (IPEndPoint)RemoteEndPoint,
+        RemoteHostStatus = IsLocal ? RemoteHostStatus.Local : RemoteHostStatus.None,
+        RecvRate         = Connection.ReadRate,
+        SendRate         = Connection.WriteRate,
+      }.Build();
     }
   }
 

--- a/PeerCastStation/PeerCastStation.PCP/PCPPongOutputStream.cs
+++ b/PeerCastStation/PeerCastStation.PCP/PCPPongOutputStream.cs
@@ -79,6 +79,8 @@ namespace PeerCastStation.PCP
   public class PCPPongOutputStream
     : OutputStreamBase
   {
+    public Guid? RemoteSessionID { get; private set; } = null;
+
     public PCPPongOutputStream(
       PeerCast peercast,
       Stream input_stream,
@@ -113,6 +115,7 @@ namespace PeerCastStation.PCP
     protected async Task OnPCPHelo(Atom atom, CancellationToken cancel_token)
     {
       var session_id = atom.Children.GetHeloSessionID();
+      RemoteSessionID = session_id;
       var oleh = new AtomCollection();
       oleh.SetHeloSessionID(PeerCast.SessionID);
       await Connection.WriteAsync(new Atom(Atom.PCP_OLEH, oleh));
@@ -150,6 +153,7 @@ namespace PeerCastStation.PCP
         RemoteName       = RemoteEndPoint.ToString(),
         RemoteEndPoint   = (IPEndPoint)RemoteEndPoint,
         RemoteHostStatus = IsLocal ? RemoteHostStatus.Local : RemoteHostStatus.None,
+        RemoteSessionID  = RemoteSessionID,
         RecvRate         = Connection.ReadRate,
         SendRate         = Connection.WriteRate,
       }.Build();

--- a/PeerCastStation/PeerCastStation.PCP/PCPSourceStream.cs
+++ b/PeerCastStation/PeerCastStation.PCP/PCPSourceStream.cs
@@ -648,6 +648,7 @@ Stopped:
         RemoteName       = remote_name,
         RemoteEndPoint   = remote_endpoint,
         RemoteHostStatus = remote,
+        RemoteSessionID  = uphost?.SessionID,
         ContentPosition  = lastPosition,
         RecvRate         = RecvRate,
         SendRate         = SendRate,

--- a/PeerCastStation/PeerCastStation.PCP/PCPSourceStream.cs
+++ b/PeerCastStation/PeerCastStation.PCP/PCPSourceStream.cs
@@ -641,19 +641,18 @@ Stopped:
         "{0}:{1}",
         SourceUri.Host,
         SourceUri.IsDefaultPort ? PCPVersion.DefaultPort : SourceUri.Port);
-      return new ConnectionInfo(
-        "PCP Source",
-        ConnectionType.Source,
-        this.Status,
-        remote_name,
-        remote_endpoint,
-        remote,
-        lastPosition,
-        RecvRate,
-        SendRate,
-        null,
-        null,
-        server_name);
+      return new ConnectionInfoBuilder {
+        ProtocolName     = "PCP Source",
+        Type             = ConnectionType.Source,
+        Status           = this.Status,
+        RemoteName       = remote_name,
+        RemoteEndPoint   = remote_endpoint,
+        RemoteHostStatus = remote,
+        ContentPosition  = lastPosition,
+        RecvRate         = RecvRate,
+        SendRate         = SendRate,
+        AgentName        = server_name,
+      }.Build();
     }
   }
 
@@ -824,19 +823,11 @@ Stopped:
         status = ConnectionStatus.Error;
         break;
       }
-      return new ConnectionInfo(
-        "PCP Source",
-        ConnectionType.Source,
-        status,
-        null,
-        null,
-        RemoteHostStatus.None,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null);
+      return new ConnectionInfoBuilder {
+        ProtocolName     = "PCP Source",
+        Type             = ConnectionType.Source,
+        Status           = status,
+      }.Build();
     }
 
     protected override ISourceConnection CreateConnection(Uri source_uri)

--- a/PeerCastStation/PeerCastStation.PCP/PCPYellowPageClient.cs
+++ b/PeerCastStation/PeerCastStation.PCP/PCPYellowPageClient.cs
@@ -73,6 +73,7 @@ namespace PeerCastStation.PCP
     }
     private List<AnnouncingChannel> announcingChannels = new List<AnnouncingChannel>();
     private AnnouncingStatus AnnouncingStatus { get; set; }
+    private Guid? RemoteSessionID { get; set; }
 
 		public class PCPYellowPageChannel
 			: IYellowPageChannel
@@ -397,6 +398,7 @@ namespace PeerCastStation.PCP
         try {
           Logger.Debug("Connecting to YP");
           AnnouncingStatus = AnnouncingStatus.Connecting;
+          RemoteSessionID = null;
           using (var client = new TcpClient(host, port)) {
             remoteEndPoint = (IPEndPoint)client.Client.RemoteEndPoint;
             using (var stream = client.GetStream()) {
@@ -503,6 +505,7 @@ namespace PeerCastStation.PCP
         }
         finally {
           remoteEndPoint = null;
+          RemoteSessionID = null;
         }
         Logger.Debug("Connection closed");
         if (!IsStopped) {
@@ -517,6 +520,7 @@ namespace PeerCastStation.PCP
 
     private void OnPCPOleh(Atom atom)
     {
+      RemoteSessionID = atom.Children.GetHeloSessionID();
       var dis = atom.Children.GetHeloDisable();
       if (dis!=null && dis.Value!=0) {
       }
@@ -657,6 +661,7 @@ namespace PeerCastStation.PCP
         RemoteName       = Name,
         RemoteEndPoint   = rhost,
         RemoteHostStatus = host_status,
+        RemoteSessionID  = RemoteSessionID,
       }.Build();
     }
 

--- a/PeerCastStation/PeerCastStation.PCP/PCPYellowPageClient.cs
+++ b/PeerCastStation/PeerCastStation.PCP/PCPYellowPageClient.cs
@@ -650,19 +650,14 @@ namespace PeerCastStation.PCP
         host_status |= RemoteHostStatus.Root;
         if (rhost.Address.IsSiteLocal()) host_status |= RemoteHostStatus.Local;
       }
-      return new ConnectionInfo(
-        "PCP COUT",
-        ConnectionType.Announce,
-        status,
-        Name,
-        rhost,
-        host_status,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null);
+      return new ConnectionInfoBuilder {
+        ProtocolName     = "PCP COUT",
+        Type             = ConnectionType.Announce,
+        Status           = status,
+        RemoteName       = Name,
+        RemoteEndPoint   = rhost,
+        RemoteHostStatus = host_status,
+      }.Build();
     }
 
 		public async System.Threading.Tasks.Task<IEnumerable<IYellowPageChannel>> GetChannelsAsync(CancellationToken cancel_token)

--- a/PeerCastStation/PeerCastStation.UI.HTTP/APIHost.cs
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/APIHost.cs
@@ -577,6 +577,7 @@ namespace PeerCastStation.UI.HTTP
         if ((info.RemoteHostStatus & RemoteHostStatus.Tracker)!=0)    remote_host_status.Add("tracker");
         res["remoteHostStatus"] = remote_host_status;
         res["remoteName"]       = info.RemoteName;
+        res["remoteSessionId"]  = info.RemoteSessionID?.ToString("N").ToUpperInvariant();
         return res;
       }
 

--- a/PeerCastStation/PeerCastStation.UI.HTTP/OWINHost.cs
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/OWINHost.cs
@@ -60,19 +60,17 @@ namespace PeerCastStation.UI.HTTP
       if (IsStopped) {
         status = HasError ? ConnectionStatus.Error : ConnectionStatus.Idle;
       }
-      return new ConnectionInfo(
-        "OWIN Host",
-        ConnectionType.Interface,
-        status,
-        RemoteEndPoint.ToString(),
-        (IPEndPoint)RemoteEndPoint,
-        IsLocal ? RemoteHostStatus.Local : RemoteHostStatus.None,
-        null,
-        Connection.ReadRate,
-        Connection.WriteRate,
-        null,
-        null,
-        request.Headers["USER-AGENT"]);
+      return new ConnectionInfoBuilder {
+        ProtocolName     = "OWIN Host",
+        Type             = ConnectionType.Interface,
+        Status           = status,
+        RemoteName       = RemoteEndPoint.ToString(),
+        RemoteEndPoint   = (IPEndPoint)RemoteEndPoint,
+        RemoteHostStatus = IsLocal ? RemoteHostStatus.Local : RemoteHostStatus.None,
+        RecvRate         = Connection.ReadRate,
+        SendRate         = Connection.WriteRate,
+        AgentName        = request.Headers["USER-AGENT"],
+      }.Build();
     }
 
     private async Task<IDictionary<string, object>> CreateOWINEnvironment(CancellationToken cancel_token)


### PR DESCRIPTION
JSON RPCで取得できるリレーツリーにはセッションIDがあるものの、
ConnectionInfoにはセッションIDがなくて対応づけが面倒だったので、
PCP接続から取れるConnectionInfoにもremoteSessionIdメンバとしてセッションIDを格納するようにした。