### PR TITLE
RTMP配信時にMPEG-2 TSに変換しつつ配信できるようにした

### DIFF
--- a/PeerCastStation/PeerCastStation.FLV/FLVToMPEG2TS.cs
+++ b/PeerCastStation/PeerCastStation.FLV/FLVToMPEG2TS.cs
@@ -900,7 +900,11 @@ namespace PeerCastStation.FLV
 
       public void OnChannelInfo(ChannelInfo channel_info)
       {
-        targetSink.OnChannelInfo(channel_info);
+        var info = new AtomCollection(channel_info.Extra);
+        info.SetChanInfoType("TS");
+        info.SetChanInfoStreamType("video/mp2t");
+        info.SetChanInfoStreamExt(".ts");
+        targetSink.OnChannelInfo(new ChannelInfo(info));
       }
 
       public void OnChannelTrack(ChannelTrack channel_track)


### PR DESCRIPTION
RTMP配信時にFLVでなくTSに変換しつつ配信できるようにURLでのパラメータでフィルタを設定できるようにした。
FLVToMPEG2TSは再生時の変換を意図していたので、コンテントタイプの再設定をしておらずに配信時に変換するとそのままFLV扱いされていたので、コンテントタイプを正しく設定しなおすようにした。