### PR TITLE
ビットレートの自己申告値が無視されていたのを修正

### DIFF
--- a/PeerCastStation/PeerCastStation.UI.HTTP/APIHost.cs
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/APIHost.cs
@@ -970,6 +970,7 @@ namespace PeerCastStation.UI.HTTP
           info.TryGetThen("genre",   v => new_info.SetChanInfoGenre(v));
           info.TryGetThen("desc",    v => new_info.SetChanInfoDesc(v));
           info.TryGetThen("comment", v => new_info.SetChanInfoComment(v));
+          info.TryGetThen("bitrate", v => new_info.SetChanInfoBitrate(v));
         }
         var channel_info  = new ChannelInfo(new_info);
         if (channel_info.Name==null || channel_info.Name=="") {


### PR DESCRIPTION
MKV配信をするとビットレートの表記が変動します。
以前は配信開始時のダイアログでビットレート値を指定してやると固定することが出来ていました。
2.3.6では出来なくなっていたので調べてみたら入力値が使われていませんでした。
（意図的でしょうか？）
自己申告値を使うようにしました。