### PR TITLE
視聴時のフィルターとして外部コマンドを通せるようにする

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/Channel.cs
+++ b/PeerCastStation/PeerCastStation.Core/Channel.cs
@@ -221,7 +221,7 @@ namespace PeerCastStation.Core
       set {
         var old = Interlocked.Exchange(ref channelInfo, value);
         if (old!=value) {
-          ChannelInfoChanged?.Invoke(this, new ChannelInfoEventArgs(value));
+          OnChannelInfoChanged(value);
         }
       }
     }
@@ -248,7 +248,7 @@ namespace PeerCastStation.Core
       set {
         var old = Interlocked.Exchange(ref channelTrack, value);
         if (old!=value) {
-          ChannelTrackChanged?.Invoke(this, new ChannelTrackEventArgs(value));
+          OnChannelTrackChanged(value);
         }
       }
     }
@@ -346,6 +346,14 @@ namespace PeerCastStation.Core
       var header = contentHeader;
       if (header!=null) {
         sink.OnContentHeader(header);
+        var channel_info = ChannelInfo;
+        if (channel_info!=null) {
+          sink.OnChannelInfo(channel_info);
+        }
+        var channel_track = ChannelTrack;
+        if (channel_track!=null) {
+          sink.OnChannelTrack(channel_track);
+        }
         var contents = Contents.GetNewerContents(header.Stream, header.Timestamp, header.Position);
         foreach (var content in contents) {
           sink.OnContent(content);
@@ -364,6 +372,22 @@ namespace PeerCastStation.Core
       return removed;
     }
 
+    private void OnChannelInfoChanged(ChannelInfo channel_info)
+    {
+      var sinks = contentSinks;
+      foreach (var sink in sinks) {
+        sink.OnChannelInfo(channel_info);
+      }
+    }
+
+    private void OnChannelTrackChanged(ChannelTrack channel_track)
+    {
+      var sinks = contentSinks;
+      foreach (var sink in sinks) {
+        sink.OnChannelTrack(channel_track);
+      }
+    }
+
     private void OnContentHeaderChanged(Content header)
     {
       var sinks = contentSinks;
@@ -377,6 +401,14 @@ namespace PeerCastStation.Core
       var header = contentHeader;
       if (header!=null) {
         OnContentHeaderChanged(header);
+        var channel_info = ChannelInfo;
+        if (channel_info!=null) {
+          OnChannelInfoChanged(channel_info);
+        }
+        var channel_track = ChannelTrack;
+        if (channel_track!=null) {
+          OnChannelTrackChanged(channel_track);
+        }
         var contents = Contents.GetNewerContents(header.Stream, header.Timestamp, header.Position);
         foreach (var content in contents) {
           OnContentAdded(content);

--- a/PeerCastStation/PeerCastStation.Core/Content.cs
+++ b/PeerCastStation/PeerCastStation.Core/Content.cs
@@ -62,6 +62,16 @@ namespace PeerCastStation.Core
       Data      = data;
       Serial    = -1;
     }
+
+    public Content(int stream, TimeSpan timestamp, long pos, byte[] data, int offset, int length)
+    {
+      Stream    = stream;
+      Timestamp = timestamp;
+      Position  = pos;
+      Data      = new byte[length];
+      Array.Copy(data, offset, this.Data, 0, length);
+      Serial    = -1;
+    }
   }
 
   public class ContentCollection

--- a/PeerCastStation/PeerCastStation.CustomFilter/CustomFilter.cs
+++ b/PeerCastStation/PeerCastStation.CustomFilter/CustomFilter.cs
@@ -1,0 +1,238 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using PeerCastStation.Core;
+using System.Xml.Linq;
+
+namespace PeerCastStation.CustomFilter
+{
+  public class CustomFilterDescription
+  {
+    public string Name              { get; private set; }
+    public string CommandLine       { get; private set; }
+    public string InputContentType  { get; private set; }
+    public string OutputContentType { get; private set; }
+    public string OutputMIMEType    { get; private set; }
+    public string OutputContentExt  { get; private set; }
+    public string BasePath          { get; private set; }
+
+    public static IEnumerable<CustomFilterDescription> Load(string filename)
+    {
+      filename = System.IO.Path.GetFullPath(filename);
+      var doc = XDocument.Load(filename);
+      return doc.Root.Elements(XName.Get("filter"))
+        .Select(filter => {
+          var desc = new CustomFilterDescription();
+          desc.Name = filter.Attribute(XName.Get("name"))?.Value;
+          desc.OutputMIMEType    = filter.Attribute(XName.Get("mimetype"))?.Value;
+          desc.OutputContentType = filter.Attribute(XName.Get("contenttype"))?.Value;
+          desc.OutputContentExt  = filter.Attribute(XName.Get("contentext"))?.Value;
+          desc.BasePath = System.IO.Path.GetDirectoryName(filename);
+          desc.CommandLine = filter.Value;
+          return desc;
+        }).ToArray();
+    }
+  }
+
+  public class CustomFilterContentSink
+    : IContentSink
+  {
+    public CustomFilterDescription Description { get; private set; }
+    public IContentSink Sink { get; private set; }
+    private System.Diagnostics.Process process = null;
+
+    public CustomFilterContentSink(CustomFilterDescription desc, IContentSink sink)
+    {
+      this.Description = desc;
+      this.Sink = sink;
+    }
+
+    public void OnChannelInfo(ChannelInfo channel_info)
+    {
+      if (String.IsNullOrEmpty(this.Description.OutputContentType)) {
+        Sink.OnChannelInfo(channel_info);
+      }
+      else {
+        var newinfo = new AtomCollection(channel_info.Extra);
+        newinfo.SetChanInfoType(this.Description.OutputContentType);
+        if (!String.IsNullOrEmpty(this.Description.OutputMIMEType)) {
+          newinfo.SetChanInfoStreamType(this.Description.OutputMIMEType);
+        }
+        if (!String.IsNullOrEmpty(this.Description.OutputContentExt)) {
+          newinfo.SetChanInfoStreamExt(this.Description.OutputContentExt);
+        }
+        Sink.OnChannelInfo(new ChannelInfo(newinfo));
+      }
+    }
+
+    public void OnChannelTrack(ChannelTrack channel_track)
+    {
+      Sink.OnChannelTrack(channel_track);
+    }
+
+    private CancellationTokenSource processCancellationToken;
+    private Task stdErrorTask;
+    private Task stdOutTask;
+    private Content lastContent = null;
+    public void OnContent(Content content)
+    {
+      lastContent = content;
+      if (process==null) {
+        var startinfo = new System.Diagnostics.ProcessStartInfo();
+        var cmd = this.Description.CommandLine;
+        var args =
+          System.Text.RegularExpressions.Regex.Matches(cmd, @"(?:""[^""]+?"")|(?:\S+)")
+          .Cast<System.Text.RegularExpressions.Match>()
+          .Select(match => match.ToString())
+          .ToArray();
+        startinfo.WorkingDirectory = this.Description.BasePath;
+        startinfo.FileName = args.First();
+        startinfo.Arguments = String.Join(" ", args.Skip(1));
+        startinfo.CreateNoWindow = false;
+        startinfo.ErrorDialog = false;
+        startinfo.RedirectStandardInput = true;
+        startinfo.RedirectStandardOutput = true;
+        startinfo.RedirectStandardError = true;
+        startinfo.StandardOutputEncoding = System.Text.Encoding.ASCII;
+        startinfo.StandardErrorEncoding = System.Text.Encoding.UTF8;
+        processCancellationToken = new CancellationTokenSource();
+        var cancel = processCancellationToken.Token;
+        process = System.Diagnostics.Process.Start(startinfo);
+        stdErrorTask = Task.Run(async () => {
+          try {
+            Logger logger = new Logger(typeof(CustomFilterContentSink), this.Description.Name);
+            while (!cancel.IsCancellationRequested) {
+              var line = await process.StandardError.ReadLineAsync();
+              logger.Debug(line);
+            }
+          }
+          catch (ObjectDisposedException) {
+          }
+        });
+        stdOutTask = Task.Run(async () => {
+          try {
+            long pos = 0;
+            var buffer = new byte[1024*15];
+            while (!cancel.IsCancellationRequested) {
+              var len = await process.StandardOutput.BaseStream.ReadAsync(buffer, 0, buffer.Length, cancel);
+              if (len<=0) break;
+              Sink.OnContent(new Content(lastContent.Stream, lastContent.Timestamp, pos, buffer, 0, len));
+              pos += len;
+            }
+          }
+          catch (ObjectDisposedException) {
+          }
+        });
+      }
+      process.StandardInput.BaseStream.Write(content.Data, 0, content.Data.Length);
+    }
+
+    public void OnContentHeader(Content content_header)
+    {
+      Sink.OnContentHeader(new Content(content_header.Stream, content_header.Timestamp, 0, new byte[0]));
+      OnContent(content_header);
+    }
+
+    public void OnStop(StopReason reason)
+    {
+      process.Close();
+      processCancellationToken.Cancel();
+      process = null;
+      processCancellationToken = null;
+    }
+  }
+
+  public class CustomFilter
+    : IContentFilter,
+      IDisposable
+  {
+    public CustomFilterDescription Description { get; private set; }
+    public string Name {
+      get { return $"custom:{Description.Name}"; }
+    }
+
+    public CustomFilter(CustomFilterDescription desc)
+    {
+      this.Description = desc;
+    }
+
+    public IContentSink Activate(IContentSink sink)
+    {
+      return new CustomFilterContentSink(this.Description, sink);
+    }
+
+    public void Dispose()
+    {
+    }
+  }
+
+  [Plugin(PluginType.Content)]
+  public class CustomFilterPlugin
+    : PluginBase
+  {
+    public override string Name => "CustomFilter Plugin";
+    public string CustomFilterPath { get; set; }
+    public List<CustomFilterDescription> Descriptions { get; private set; }
+    private IEnumerable<CustomFilter> filters = null;
+
+    public CustomFilterPlugin()
+    {
+      this.CustomFilterPath =
+        System.IO.Path.Combine(
+          Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+          "PeerCastStation",
+          "Filters");
+    }
+
+    override protected void OnAttach()
+    {
+      Descriptions = LoadDescriptions().ToList();
+    }
+
+    override protected void OnDetach()
+    {
+      Descriptions.Clear();
+    }
+
+    override protected void OnStart()
+    {
+      if (filters!=null) return;
+      filters = Descriptions.Select(desc => new CustomFilter(desc)).ToArray();
+      foreach (var filter in filters) {
+        Application.PeerCast.ContentFilters.Add(filter);
+      }
+    }
+
+    override protected void OnStop()
+    {
+      if (filters==null) return;
+      foreach (var filter in filters) {
+        Application.PeerCast.ContentFilters.Remove(filter);
+      }
+      filters = null;
+    }
+
+    public IEnumerable<CustomFilterDescription> LoadDescriptions()
+    {
+      return
+        System.IO.Directory.GetFiles(CustomFilterPath, "*.xml")
+        .SelectMany(file => CustomFilterDescription.Load(file));
+    }
+
+    public void Restart()
+    {
+      OnStop();
+      OnStart();
+    }
+
+    public void Reload()
+    {
+      OnDetach();
+      OnAttach();
+      Restart();
+    }
+  }
+
+}

--- a/PeerCastStation/PeerCastStation.CustomFilter/PeerCastStation.CustomFilter.csproj
+++ b/PeerCastStation/PeerCastStation.CustomFilter/PeerCastStation.CustomFilter.csproj
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E45E0A0A-4ACC-4B46-A4B4-E2D836BDE3DD}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>PeerCastStation.CustomFilter</RootNamespace>
+    <AssemblyName>PeerCastStation.CustomFilter</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>../PeerCastStation.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.XML" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CustomFilter.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\PeerCastStation.Core\PeerCastStation.Core.csproj">
+      <Project>{387996f5-e31d-4d92-bd86-8983c599f748}</Project>
+      <Name>PeerCastStation.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="../PeerCastStation.snk" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/PeerCastStation/PeerCastStation.CustomFilter/Properties/AssemblyInfo.cs
+++ b/PeerCastStation/PeerCastStation.CustomFilter/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// アセンブリに関する一般情報は以下の属性セットをとおして制御されます。
+// アセンブリに関連付けられている情報を変更するには、
+// これらの属性値を変更してください。
+[assembly: AssemblyTitle("PeerCastStation.CustomFilter")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("PeerCastStation.CustomFilter")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// ComVisible を false に設定すると、このアセンブリ内の型は COM コンポーネントから
+// 参照できなくなります。COM からこのアセンブリ内の型にアクセスする必要がある場合は、
+// その型の ComVisible 属性を true に設定してください。
+[assembly: ComVisible(false)]
+
+// このプロジェクトが COM に公開される場合、次の GUID が typelib の ID になります
+[assembly: Guid("e45e0a0a-4acc-4b46-a4b4-e2d836bde3dd")]
+
+// アセンブリのバージョン情報は次の 4 つの値で構成されています:
+//
+//      メジャー バージョン
+//      マイナー バージョン
+//      ビルド番号
+//      Revision
+//
+// すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
+// 以下のように '*' を使用します:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/PeerCastStation/PeerCastStation.sln
+++ b/PeerCastStation/PeerCastStation.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.7
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PeerCastStation.Core", "PeerCastStation.Core\PeerCastStation.Core.csproj", "{387996F5-E31D-4D92-BD86-8983C599F748}"
 EndProject
@@ -80,6 +80,8 @@ EndProject
 Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "PecaStationdInstaller", "PecaStationdInstaller\PecaStationdInstaller.wixproj", "{380048CC-CCEC-4864-B7B1-60E9360560B9}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PeerCastStation.TS", "PeerCastStation.TS\PeerCastStation.TS.csproj", "{0F0123AE-E500-45CA-B69D-4FBDBB88B752}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PeerCastStation.CustomFilter", "PeerCastStation.CustomFilter\PeerCastStation.CustomFilter.csproj", "{E45E0A0A-4ACC-4B46-A4B4-E2D836BDE3DD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -166,6 +168,10 @@ Global
 		{0F0123AE-E500-45CA-B69D-4FBDBB88B752}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0F0123AE-E500-45CA-B69D-4FBDBB88B752}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0F0123AE-E500-45CA-B69D-4FBDBB88B752}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E45E0A0A-4ACC-4B46-A4B4-E2D836BDE3DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E45E0A0A-4ACC-4B46-A4B4-E2D836BDE3DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E45E0A0A-4ACC-4B46-A4B4-E2D836BDE3DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E45E0A0A-4ACC-4B46-A4B4-E2D836BDE3DD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/PeerCastStation/PeerCastStation/PeerCastStation.csproj
+++ b/PeerCastStation/PeerCastStation/PeerCastStation.csproj
@@ -74,6 +74,10 @@
       <Project>{387996F5-E31D-4D92-BD86-8983C599F748}</Project>
       <Name>PeerCastStation.Core</Name>
     </ProjectReference>
+    <ProjectReference Include="..\PeerCastStation.CustomFilter\PeerCastStation.CustomFilter.csproj">
+      <Project>{e45e0a0a-4acc-4b46-a4b4-e2d836bde3dd}</Project>
+      <Name>PeerCastStation.CustomFilter</Name>
+    </ProjectReference>
     <ProjectReference Include="..\PeerCastStation.FLV\PeerCastStation.FLV.csproj">
       <Project>{895D4DF8-A8B2-43A0-85E4-ED74152E73B2}</Project>
       <Name>PeerCastStation.FLV</Name>


### PR DESCRIPTION
視聴時に外部コマンドでコンテナ変換や再エンコードができるよう、標準入出力を使って外部コマンドでのフィルタリングをするCustomFilterを追加する。