### PR TITLE
チャンネルのリレーツリーを実際の接続を見て作るようにした

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/HostTree.cs
+++ b/PeerCastStation/PeerCastStation.Core/HostTree.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 
@@ -7,32 +6,55 @@ namespace PeerCastStation.Core
 {
   public class HostTree
   {
-    public IEnumerable<HostTreeNode> Nodes { get; private set; }
-    public HostTree(IEnumerable<Host> hosts)
+    public IList<HostTreeNode> Nodes { get; private set; }
+
+    public HostTree(IList<HostTreeNode> nodes)
     {
-      var nodes = new Dictionary<IPEndPoint, HostTreeNode>();
-      var roots = new List<HostTreeNode>();
-      foreach (var host in hosts) {
-        var endpoint = (host.GlobalEndPoint==null || host.GlobalEndPoint.Port==0) ? host.LocalEndPoint : host.GlobalEndPoint;
-        if (endpoint==null) continue;
-        nodes[endpoint] = new HostTreeNode(host);
-      }
-      foreach (var node in nodes.Values) {
-        var uphost = node.Host.Extra.GetHostUphostEndPoint();
-        if (uphost!=null && nodes.ContainsKey(uphost)) {
-          nodes[uphost].Children.Add(node);
-        }
-        else {
-          roots.Add(node);
-        }
-      }
-      Nodes = roots;
+      this.Nodes = nodes;
     }
 
     public HostTree(Channel channel)
-      : this(new Host[] { channel.SelfNode }.Concat(channel.Nodes))
+      : this(new HostTreeNode[] { CreateChannelHostTree(channel) })
     {
     }
+
+    public static IList<HostTreeNode> CreateHostTree(IEnumerable<Host> hosts)
+    {
+      var nodemap = new Dictionary<IPEndPoint, HostTreeNode>();
+      var topnodes = new List<HostTreeNode>();
+      foreach (var host in hosts) {
+        var endpoint = (host.GlobalEndPoint==null || host.GlobalEndPoint.Port==0) ? host.LocalEndPoint : host.GlobalEndPoint;
+        if (endpoint==null) continue;
+        nodemap[endpoint] = new HostTreeNode(host);
+      }
+      foreach (var node in nodemap.Values) {
+        var uphost = node.Host.Extra.GetHostUphostEndPoint();
+        if (uphost!=null && nodemap.ContainsKey(uphost)) {
+          nodemap[uphost].Children.Add(node);
+        }
+        else {
+          topnodes.Add(node);
+        }
+      }
+      return topnodes;
+    }
+
+    public static HostTreeNode CreateChannelHostTree(Channel channel)
+    {
+      var nodes = channel.Nodes;
+      var children =
+        channel.OutputStreams
+          .Select(os => os.GetConnectionInfo())
+          .Where(ci => ci.Type.HasFlag(ConnectionType.Relay))
+          .Where(ci => ci.RemoteSessionID!=null)
+          .Select(ci => nodes.SingleOrDefault(node => node.SessionID==ci.RemoteSessionID.Value))
+          .Where(node => node!=null);
+      var tree = CreateHostTree(nodes);
+      return new HostTreeNode(
+        channel.SelfNode,
+        tree.Where(node => children.Contains(node.Host)).ToArray());
+    }
+
   }
 
   public class HostTreeNode
@@ -43,6 +65,12 @@ namespace PeerCastStation.Core
     {
       this.Host = host;
       this.Children = new List<HostTreeNode>();
+    }
+
+    public HostTreeNode(Host host, IList<HostTreeNode> children)
+    {
+      this.Host = host;
+      this.Children = children;
     }
   }
 


### PR DESCRIPTION
チャンネルのリレーツリーは現在把握してるノード情報から作っていたが、現在はもう接続されてない下流ノードの情報もつながっているものとしてツリーに追加されていたので、現在つながってるノード以下のみツリーに入れるようにした