### PR TITLE
Accept待ちの接続要求数を制限できるようにしてみた

### DIFF
--- a/PeerCastStation/PecaStationd/app.config
+++ b/PeerCastStation/PecaStationd/app.config
@@ -4,6 +4,7 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
   </startup>
   <appSettings>
+    <add key="MaxPendingConnections" value="5" />
     <add key="DefaultListenAddress" value="0.0.0.0" />
     <add key="DefaultListenPort" value="7144" />
     <add key="AgentName" value="PeerCastStation/2.3.8.0"/>

--- a/PeerCastStation/PecaStationdDebug/App.config
+++ b/PeerCastStation/PecaStationdDebug/App.config
@@ -4,6 +4,7 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
   </startup>
   <appSettings>
+    <add key="MaxPendingConnections" value="5" />
     <add key="DefaultListenAddress" value="0.0.0.0"/>
     <add key="DefaultListenPort" value="7144"/>
     <add key="AgentName" value="PeerCastStation/1.9.1.0"/>

--- a/PeerCastStation/PeerCastStation.App/AppBase.cs
+++ b/PeerCastStation/PeerCastStation.App/AppBase.cs
@@ -71,6 +71,7 @@ namespace PeerCastStation.App
       }
       peerCast.AddChannelMonitor(new ChannelCleaner(peerCast));
       peerCast.AddChannelMonitor(new ChannelNotifier(this));
+      LoadConfigurations();
       LoadSettings();
       foreach (var plugin in Plugins) {
         plugin.Start();
@@ -131,6 +132,14 @@ namespace PeerCastStation.App
       })
       .Where(plugin => plugin!=null)
       .ToArray();
+    }
+
+    void LoadConfigurations()
+    {
+      int backlog;
+      if (AppSettingsReader.TryGetInt("MaxPendingConnections", out backlog) && backlog>0) {
+        OutputListener.MaxPendingConnections = backlog;
+      }
     }
 
     void LoadSettings()

--- a/PeerCastStation/PeerCastStation.Core/OutputListener.cs
+++ b/PeerCastStation/PeerCastStation.Core/OutputListener.cs
@@ -36,6 +36,7 @@ namespace PeerCastStation.Core
     : IDisposable
   {
     private static Logger logger = new Logger(typeof(OutputListener));
+    public static int MaxPendingConnections { get; set; } = Int32.MaxValue;
     /// <summary>
     /// 所属しているPeerCastオブジェクトを取得します
     /// </summary>
@@ -173,7 +174,7 @@ namespace PeerCastStation.Core
         //Windows以外は明示的には付けないようにした。
         server.Server.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
       }
-      server.Start(Int32.MaxValue);
+      server.Start(MaxPendingConnections);
       listenTask = StartListen(server, cancellationSource.Token);
     }
 

--- a/PeerCastStation/PeerCastStation/app.config
+++ b/PeerCastStation/PeerCastStation/app.config
@@ -16,6 +16,7 @@
     </PeerCastStation.Properties.Settings>
   </userSettings>
   <appSettings>
+    <add key="MaxPendingConnections" value="5" />
     <add key="DefaultListenAddress" value="0.0.0.0" />
     <add key="DefaultListenPort" value="7144" />
     <add key="AgentName" value="PeerCastStation/2.3.8.0"/>


### PR DESCRIPTION
同時に接続要求が行われた際に処理がいっぱいになってしまう可能性があったので、無制限だったAccept待ちの接続要求を設定できるようにしてみた。
～.exe.configのMaxPendingConnections設定で指定した値を使う。
標準はとりあえず5にしてみた。