### PR TITLE
&pls=m3uオプションが効いていなかったのを修正

### DIFF
--- a/PeerCastStation/PeerCastStation.HTTP/HTTPOutputStream.cs
+++ b/PeerCastStation/PeerCastStation.HTTP/HTTPOutputStream.cs
@@ -568,17 +568,7 @@ namespace PeerCastStation.HTTP
     private async Task SendPlaylist(CancellationToken cancel_token)
     {
       Logger.Debug("Sending Playlist");
-      bool mms = 
-        channelInfo.ContentType=="WMV" ||
-        channelInfo.ContentType=="WMA" ||
-        channelInfo.ContentType=="ASX";
-      IPlayList pls;
-      if (mms) {
-        pls = new ASXPlayList();
-      }
-      else {
-        pls = new M3UPlayList();
-      }
+      var pls = CreatePlaylist();
       pls.Channels.Add(Channel);
       var baseuri = new Uri(
         new Uri(request.Uri.GetComponents(UriComponents.SchemeAndServer | UriComponents.UserInfo, UriFormat.UriEscaped)),


### PR DESCRIPTION
リスナーさんから2.3.8でWMV配信が見られないと書き込みがあったので調べてみました。

2.2.1では http://localhost:7144/pls/XXXXXX?tip=0000000:7144&pls=m3u
とした時URLのみのm3uファイルが返ってきていましたが
2.3.8では中身がasxで拡張子がm3uのファイルが返ってきます。

PeercastStation * pcypLite * mpv系プレイヤーの視聴環境では
mpvがasxを解釈できない * pcypLiteがストリームURLをプレイヤーに吐けない
のコンボを食らうので、&plsオプションが有用でした。

調べてみたらAsync化の作業中にGetPlaylistFormatを用いた
plsオプションの解析コードが抜け落ちてしまっていた様でした。
