### PR TITLE
XSplitで上手くRTMP接続できないのに対策を入れた

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/SourceConnectionBase.cs
+++ b/PeerCastStation/PeerCastStation.Core/SourceConnectionBase.cs
@@ -72,7 +72,7 @@ namespace PeerCastStation.Core
         }
       }
 
-      public void Dispose()
+      public virtual void Dispose()
       {
         remoteEndPoint = null;
         this.Stream.Close();


### PR DESCRIPTION
XSplitが不可解な動作とどう見てもバグな動作をしてきて上手くRTMPで配信できないので対策を入れた。
どちらかというとXSplitがおかしいので、要望が無い限りはマージしないこととする。

XSplitは配信接続したあとになぜかポートチェックと称してもう一本接続をしてきて、そいつの接続を受け入れないと既につながった配信接続を切ってくるので、配信接続ができたあとも接続自体は受け入れてすぐ切るようにした。
ポートチェックの接続はすぐ切っても大丈夫なようだ。
普通のRTMPサーバーなら問題ないだろうが、PeerCastStationでは一度接続を受け付けたら、接続待ち受けを終了するようにしていたのでポートチェックの接続ができなかった。
ずっと接続を受け付けるようにすると、ポートを無駄に占有してよろしくないが、実用上は問題ないと思われる。

RTMPではタイムデルタに0xFFFFFFが設定された時には拡張時間フィールドがあることになっているが、XSplitはタイムデルタに0xFFFFFFを設定しつつ拡張時間フィールド無しのデータを送ってきてその後のデータが全部ずれてしまうため、XSplitであることを検出したらタイムデルタの拡張時間フィールドは読み込まないようにした。
これは仕様書から外れた動作をするXSplitのバグにしか思えないが、他のサーバーではなんで問題になってないんだろう……。