### PR TITLE
MediaFoundationとUWPのMediaElementでのWMV配信の再生が出来ないバグを修正

### DIFF
--- a/PeerCastStation/PeerCastStation.HTTP/HTTPOutputStream.cs
+++ b/PeerCastStation/PeerCastStation.HTTP/HTTPOutputStream.cs
@@ -421,13 +421,27 @@ namespace PeerCastStation.HTTP
             channelInfo.ContentType=="WMA" ||
             channelInfo.ContentType=="ASX";
           if (mms) {
-            return
-              "HTTP/1.0 200 OK\r\n"                         +
-              "Server: Rex/9.0.2980\r\n"                    +
-              "Cache-Control: no-cache\r\n"                 +
-              "Pragma: no-cache\r\n"                        +
-              "Pragma: features=\"broadcast,playlist\"\r\n" +
-              "Content-Type: application/x-mms-framed\r\n";
+            if ((request.Headers.ContainsKey("PRAGMA") && request.Headers["PRAGMA"].Contains("stream-switch")) ||
+                (request.Headers.ContainsKey("USER-AGENT") && request.Headers["USER-AGENT"].Contains("Kagamin2"))) {
+              return
+                "HTTP/1.0 200 OK\r\n"                         +
+                "Server: Rex/9.0.2980\r\n"                    +
+                "Cache-Control: no-cache\r\n"                 +
+                "Pragma: no-cache\r\n"                        +
+                "Pragma: features=\"broadcast,playlist\"\r\n" +
+                "Content-Type: application/x-mms-framed\r\n";
+            }
+            else {
+              return
+                "HTTP/1.0 200 OK\r\n"                                +
+                "Server: Rex/9.0.2980\r\n"                           +
+                "Cache-Control: no-cache\r\n"                        +
+                "Pragma: no-cache\r\n"                               +
+                "Pragma: features=\"broadcast,playlist\"\r\n"        +
+                "Content-Type: application/vnd.ms.wms-hdr.asfv1\r\n" +
+                $"Content-Length: {headerContent.Data.Length}\r\n"   +
+                "Connection: Keep-Alive\r\n";
+            }
           }
           else {
             return
@@ -548,6 +562,16 @@ namespace PeerCastStation.HTTP
               sent_header = packet.Content;
               sent_packet = packet.Content;
             }
+
+            bool mms =
+              Channel.ChannelInfo.ContentType == "WMV" ||
+              Channel.ChannelInfo.ContentType == "WMA" ||
+              Channel.ChannelInfo.ContentType == "ASX";
+
+            if (mms && !((request.Headers.ContainsKey("PRAGMA") && request.Headers["PRAGMA"].Contains("stream-switch")) ||
+                         (request.Headers.ContainsKey("USER-AGENT") && request.Headers["USER-AGENT"].Contains("Kagamin2"))))
+              return;
+
             break;
           case Packet.ContentType.Body:
             if (sent_header==null) continue;

--- a/PeerCastStation/PeerCastStation.HTTP/HTTPOutputStream.cs
+++ b/PeerCastStation/PeerCastStation.HTTP/HTTPOutputStream.cs
@@ -428,7 +428,7 @@ namespace PeerCastStation.HTTP
                 "Server: Rex/9.0.2980\r\n"                    +
                 "Cache-Control: no-cache\r\n"                 +
                 "Pragma: no-cache\r\n"                        +
-                "Pragma: features=\"broadcast,playlist\"\r\n" +
+                "Pragma: features=\"seekable,stridable\"\r\n" +
                 "Content-Type: application/x-mms-framed\r\n";
             }
             else {
@@ -437,7 +437,7 @@ namespace PeerCastStation.HTTP
                 "Server: Rex/9.0.2980\r\n"                           +
                 "Cache-Control: no-cache\r\n"                        +
                 "Pragma: no-cache\r\n"                               +
-                "Pragma: features=\"broadcast,playlist\"\r\n"        +
+                "Pragma: features=\"seekable,stridable\"\r\n"        +
                 "Content-Type: application/vnd.ms.wms-hdr.asfv1\r\n" +
                 $"Content-Length: {headerContent.Data.Length}\r\n"   +
                 "Connection: Keep-Alive\r\n";

--- a/PeerCastStation/PeerCastStation.HTTP/HTTPRequest.cs
+++ b/PeerCastStation/PeerCastStation.HTTP/HTTPRequest.cs
@@ -98,8 +98,8 @@ namespace PeerCastStation.HTTP
           }
         }
         else if ((match = Regex.Match(req, @"^(\S*):(.+)$", RegexOptions.IgnoreCase)).Success) {
-          if (Headers.ContainsKey(match.Groups[1].Value.ToUpper())) {
-            Headers[match.Groups[1].Value.ToUpper()] += "\n" + match.Groups[2].Value.Trim();
+          if (match.Groups[1].Value.ToUpper() == "PRAGMA" && Headers.ContainsKey("PRAGMA")) {
+            Headers["PRAGMA"] += "\n" + match.Groups[2].Value.Trim();
           }
           else {
             Headers[match.Groups[1].Value.ToUpper()] = match.Groups[2].Value.Trim();

--- a/PeerCastStation/PeerCastStation.HTTP/HTTPRequest.cs
+++ b/PeerCastStation/PeerCastStation.HTTP/HTTPRequest.cs
@@ -98,7 +98,12 @@ namespace PeerCastStation.HTTP
           }
         }
         else if ((match = Regex.Match(req, @"^(\S*):(.+)$", RegexOptions.IgnoreCase)).Success) {
-          Headers[match.Groups[1].Value.ToUpper()] = match.Groups[2].Value.Trim();
+          if (Headers.ContainsKey(match.Groups[1].Value.ToUpper())) {
+            Headers[match.Groups[1].Value.ToUpper()] += "\n" + match.Groups[2].Value.Trim();
+          }
+          else {
+            Headers[match.Groups[1].Value.ToUpper()] = match.Groups[2].Value.Trim();
+          }
         }
       }
       Uri uri;


### PR DESCRIPTION
MediaFoundationとUWPのMediaElementで
mmsプロトコルを使った再生ができないので原因を調べたところ
Content-Type: application/vnd.ms.wms-hdr.asfv1を送ってないのが原因でした
あと試す時は再生する時にhttp://をmms://に変えて再生して下さい

mms://のURLを再生できるMediaFoundationのプレイヤーのサンプル。ビルドして使えます
https://github.com/Microsoft/Windows-classic-samples/tree/master/Samples/Win7Samples/multimedia/mediafoundation/protectedplayback

protectedplaybackのビルドで足りないソースはここから入手できます
https://github.com/Microsoft/Windows-classic-samples/tree/master/Samples/Win7Samples/multimedia/mediafoundation/common

それと、この変更でKagamin2のリレーが出来なくなったのでそれも直しておきました