### PR TITLE
WMV配信のプレイリストのURI schemeを切り替えられるように修正

### DIFF
--- a/PeerCastStation/PeerCastStation.HTTP/HTTPOutputStream.cs
+++ b/PeerCastStation/PeerCastStation.HTTP/HTTPOutputStream.cs
@@ -407,6 +407,17 @@ namespace PeerCastStation.HTTP
       }
     }
 
+    private string GetPlaylistScheme()
+    {
+      string scheme;
+      if (request.Parameters.TryGetValue("scheme", out scheme)) {
+        return scheme;
+      }
+      else {
+        return null;
+      }
+    }
+
     private string GetPlaylistFormat()
     {
       string fmt;
@@ -418,27 +429,28 @@ namespace PeerCastStation.HTTP
       }
     }
 
-    private IPlayList CreateDefaultPlaylist()
+    private IPlayList CreateDefaultPlaylist(string scheme)
     {
       if (IsChannelASF) {
-        return new ASXPlayList();
+        return new ASXPlayList(scheme);
       }
       else {
-        return new M3UPlayList();
+        return new M3UPlayList(scheme);
       }
     }
 
     private IPlayList CreatePlaylist()
     {
+      var scheme = GetPlaylistScheme();
       var fmt = GetPlaylistFormat();
       if (String.IsNullOrEmpty(fmt)) {
-        return CreateDefaultPlaylist();
+        return CreateDefaultPlaylist(scheme);
       }
       else {
         switch (fmt.ToLowerInvariant()) {
-        case "asx": return new ASXPlayList();
-        case "m3u": return new M3UPlayList();
-        default:    return CreateDefaultPlaylist();
+        case "asx": return new ASXPlayList(scheme);
+        case "m3u": return new M3UPlayList(scheme);
+        default:    return CreateDefaultPlaylist(scheme);
         }
       }
     }

--- a/PeerCastStation/PeerCastStation.HTTP/PlayList.cs
+++ b/PeerCastStation/PeerCastStation.HTTP/PlayList.cs
@@ -55,7 +55,7 @@ namespace PeerCastStation.HTTP
 
     public M3UPlayList(string scheme)
     {
-      this.scheme = String.IsNullOrEmpty(scheme) ? "mms" : scheme.ToLowerInvariant();
+      this.scheme = String.IsNullOrEmpty(scheme) ? "http" : scheme.ToLowerInvariant();
       Channels = new List<Channel>();
     }
 
@@ -65,13 +65,7 @@ namespace PeerCastStation.HTTP
       var queries = String.Join("&", parameters.Select(kv => Uri.EscapeDataString(kv.Key) + "=" + Uri.EscapeDataString(kv.Value)));
       foreach (var c in Channels) {
         var url = new UriBuilder(new Uri(baseuri, c.ChannelID.ToString("N").ToUpper() + c.ChannelInfo.ContentExtension));
-        bool mms = 
-          c.ChannelInfo.ContentType=="WMV" ||
-          c.ChannelInfo.ContentType=="WMA" ||
-          c.ChannelInfo.ContentType=="ASX";
-        if (mms) {
-          url.Scheme = scheme;
-        }
+        url.Scheme = scheme;
         if (queries!="") {
           url.Query = queries;
         }

--- a/PeerCastStation/PeerCastStation.HTTP/PlayList.cs
+++ b/PeerCastStation/PeerCastStation.HTTP/PlayList.cs
@@ -49,11 +49,13 @@ namespace PeerCastStation.HTTP
   public class M3UPlayList
     : IPlayList
   {
+    public string scheme;
     public string MIMEType { get { return "audio/x-mpegurl"; } }
     public IList<Channel> Channels { get; private set; }
 
-    public M3UPlayList()
+    public M3UPlayList(string scheme)
     {
+      this.scheme = String.IsNullOrEmpty(scheme) ? "mms" : scheme.ToLowerInvariant();
       Channels = new List<Channel>();
     }
 
@@ -68,7 +70,7 @@ namespace PeerCastStation.HTTP
           c.ChannelInfo.ContentType=="WMA" ||
           c.ChannelInfo.ContentType=="ASX";
         if (mms) {
-          url.Scheme = "mms";
+          url.Scheme = scheme;
         }
         if (queries!="") {
           url.Query = queries;
@@ -85,11 +87,13 @@ namespace PeerCastStation.HTTP
   public class ASXPlayList
     : IPlayList
   {
+    public string scheme;
     public string MIMEType { get { return "video/x-ms-asf"; } }
     public IList<Channel> Channels { get; private set; }
 
-    public ASXPlayList()
+    public ASXPlayList(string scheme)
     {
+      this.scheme = String.IsNullOrEmpty(scheme) ? "mms" : scheme.ToLowerInvariant();
       Channels = new List<Channel>();
     }
 
@@ -111,7 +115,7 @@ namespace PeerCastStation.HTTP
           contact_url = c.ChannelInfo.URL;
         }
         var stream_url = new UriBuilder(baseuri);
-        stream_url.Scheme = "mms";
+        stream_url.Scheme = scheme;
         if (stream_url.Path[stream_url.Path.Length-1]!='/') {
           stream_url.Path += '/';
         }


### PR DESCRIPTION
ペカステがMediaFoundationに対応してくれたおかげで
WMV(H264+AAC)配信がWMPでコーデック無しで再生できるようになったのですが
WMV配信のプレイリストの中の配信URLがmms固定のためプレイヤーの設定に苦労します
PeCaRecoderだと"httpt://$Z/stream/$1?tip=$2"で上手く行くのですが
pcypLiteだと$Zとか無いのでプレイヤーの設定ができません

プレイリストURLにクエリ文字列でURI schemeを切り替えられれば
PeCaRecoderなら
"$x&scheme=httpt"
pcypLiteなら
"&lt;stream/&gt;&scheme=httpt"
こんな感じにすればプレイヤーの設定が上手く行くので修正しました
