### PR TITLE
[WIP] 分離型の置き換えアップデータを追加する

### DIFF
--- a/PeerCastStation/PecaStationd/PecaStationd.csproj
+++ b/PeerCastStation/PecaStationd/PecaStationd.csproj
@@ -89,6 +89,10 @@
       <Project>{387996f5-e31d-4d92-bd86-8983c599f748}</Project>
       <Name>PeerCastStation.Core</Name>
     </ProjectReference>
+    <ProjectReference Include="..\PeerCastStation.CustomFilter\PeerCastStation.CustomFilter.csproj">
+      <Project>{e45e0a0a-4acc-4b46-a4b4-e2d836bde3dd}</Project>
+      <Name>PeerCastStation.CustomFilter</Name>
+    </ProjectReference>
     <ProjectReference Include="..\PeerCastStation.FLV\PeerCastStation.FLV.csproj">
       <Project>{895d4df8-a8b2-43a0-85e4-ed74152e73b2}</Project>
       <Name>PeerCastStation.FLV</Name>
@@ -105,6 +109,10 @@
       <Project>{f9d126c6-76b7-45e2-b62e-6ac35ee285cd}</Project>
       <Name>PeerCastStation.PCP</Name>
     </ProjectReference>
+    <ProjectReference Include="..\PeerCastStation.TS\PeerCastStation.TS.csproj">
+      <Project>{0f0123ae-e500-45ca-b69d-4fbdbb88b752}</Project>
+      <Name>PeerCastStation.TS</Name>
+    </ProjectReference>
     <ProjectReference Include="..\PeerCastStation.UI.HTTP\PeerCastStation.UI.HTTP.csproj">
       <Project>{bf5e0b6d-961a-4216-bacf-01d80ab3d6bb}</Project>
       <Name>PeerCastStation.UI.HTTP</Name>
@@ -113,9 +121,9 @@
       <Project>{5988fbaf-37c4-4997-8389-55f2ebbb9511}</Project>
       <Name>PeerCastStation.UI</Name>
     </ProjectReference>
-    <ProjectReference Include="..\PeerCastStation.WPF\PeerCastStation.WPF.csproj">
-      <Project>{5ea68141-ac06-428b-9526-a6835e0cc2b2}</Project>
-      <Name>PeerCastStation.WPF</Name>
+    <ProjectReference Include="..\PeerCastStation.Updater\PeerCastStation.Updater.csproj">
+      <Project>{be5fd77b-d20e-40f6-b198-c7fd97e41274}</Project>
+      <Name>PeerCastStation.Updater</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/PeerCastStation/PecaStationd/PeerCastStationServiceMain.cs
+++ b/PeerCastStation/PecaStationd/PeerCastStationServiceMain.cs
@@ -1,147 +1,27 @@
 ﻿using System;
-using System.Runtime.Remoting.Lifetime;
 using System.Threading.Tasks;
+using PeerCastStation.App;
 
 namespace PecaStationd
 {
   public class PeerCastStationServiceMain
   {
-    class ResultContainer : MarshalByRefObject
-    {
-      public override Object InitializeLifetimeService()
-      {
-        var lease = (ILease)base.InitializeLifetimeService();
-        if (lease.CurrentState==LeaseState.Initial) {
-          lease.InitialLeaseTime = TimeSpan.Zero;
-        }
-        return lease;
-      }
-
-      public AppContext AppContext;
-    }
-
-    class AppContext : MarshalByRefObject
-    {
-      public override Object InitializeLifetimeService()
-      {
-        var lease = (ILease)base.InitializeLifetimeService();
-        if (lease.CurrentState==LeaseState.Initial) {
-          lease.InitialLeaseTime = TimeSpan.Zero;
-        }
-        return lease;
-      }
-
-      public object serviceApp;
-      public Task<int> mainTask;
-      public Action<int> onStoppedCallback;
-
-      public AppContext(string basepath, string[] args)
-      {
-        var asm = System.Reflection.Assembly.LoadFrom(
-          System.IO.Path.Combine(basepath, "PeerCastStation.App.dll"));
-        var type = asm.GetType("PeerCastStation.App.ServiceApp");
-        serviceApp = type.InvokeMember("ServiceApp",
-          System.Reflection.BindingFlags.CreateInstance,
-          null,
-          null,
-          new object[] { basepath });
-        mainTask = (Task<int>)serviceApp.GetType().InvokeMember("Start",
-          System.Reflection.BindingFlags.Public |
-          System.Reflection.BindingFlags.Instance |
-          System.Reflection.BindingFlags.InvokeMethod,
-          null,
-          serviceApp,
-          new object[] { });
-        mainTask = mainTask.ContinueWith(prev => {
-          if (prev.IsCanceled || prev.IsFaulted) return 1;
-          onStoppedCallback?.Invoke(prev.Result);
-          return prev.Result;
-        });
-      }
-
-      public void SetOnStopped(Action<int> callback)
-      {
-        onStoppedCallback = callback;
-        if (onStoppedCallback!=null && mainTask.IsCompleted) {
-          onStoppedCallback(mainTask.Result);
-        }
-      }
-
-      public int Stop()
-      {
-        serviceApp.GetType().InvokeMember("Stop",
-          System.Reflection.BindingFlags.Public |
-          System.Reflection.BindingFlags.Instance |
-          System.Reflection.BindingFlags.InvokeMethod,
-          null,
-          serviceApp,
-          new object[] { });
-        mainTask.Wait();
-        return mainTask.Result;
-      }
-    }
-
-    [Serializable]
-    class StartUpContext
-    {
-      public string   BasePath;
-      public string[] Args;
-      public ResultContainer Result;
-
-      public void Start()
-      {
-        Result.AppContext = new AppContext(this.BasePath, this.Args);
-      }
-    }
-
-    private AppContext appContext;
-    public int Result { get; private set; } = -1;
-
-    private class StoppedCallback : MarshalByRefObject
-    {
-      public override Object InitializeLifetimeService()
-      {
-        var lease = (ILease)base.InitializeLifetimeService();
-        if (lease.CurrentState==LeaseState.Initial) {
-          lease.InitialLeaseTime = TimeSpan.Zero;
-        }
-        return lease;
-      }
-
-      public PeerCastStationServiceMain Owner;
-      public string[] Args;
-      public void OnStopped(int result)
-      {
-        if (result==-1) Owner.Start(Args);
-        else            Owner.Result = result;
-      }
-    }
-
-    private StoppedCallback stoppedCallback;
+    private ServiceApp application;
+    private Task<int> appTask;
     public void Start(string[] args)
     {
       var basepath = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetEntryAssembly().Location);
-      var appdomain = AppDomain.CreateDomain(
-        "PeerCastStaion.App",
-        null,
-        AppDomain.CurrentDomain.BaseDirectory,
-        AppDomain.CurrentDomain.RelativeSearchPath,
-        true);
-      var ctx = new StartUpContext() {
-        BasePath = basepath,
-        Args     = args,
-        Result   = new ResultContainer { AppContext = null },
-      };
-      var d = new CrossAppDomainDelegate(ctx.Start);
-      appdomain.DoCallBack(d);
-      appContext = ctx.Result.AppContext;
-      stoppedCallback = new StoppedCallback { Owner=this, Args=args, };
-      appContext.SetOnStopped(new Action<int>(stoppedCallback.OnStopped));
+      application = new ServiceApp(basepath);
+      appTask = application.Start();
     }
 
     public int Stop()
     {
-      return appContext.Stop();
+      if (application==null) return -2;
+      application.Stop();
+      appTask.Wait();
+      return appTask.Result;
     }
   }
+
 }

--- a/PeerCastStation/PecaStationdDebug/PecaStationdDebug.csproj
+++ b/PeerCastStation/PecaStationdDebug/PecaStationdDebug.csproj
@@ -59,6 +59,10 @@
       <Project>{387996f5-e31d-4d92-bd86-8983c599f748}</Project>
       <Name>PeerCastStation.Core</Name>
     </ProjectReference>
+    <ProjectReference Include="..\PeerCastStation.CustomFilter\PeerCastStation.CustomFilter.csproj">
+      <Project>{e45e0a0a-4acc-4b46-a4b4-e2d836bde3dd}</Project>
+      <Name>PeerCastStation.CustomFilter</Name>
+    </ProjectReference>
     <ProjectReference Include="..\PeerCastStation.FLV\PeerCastStation.FLV.csproj">
       <Project>{895d4df8-a8b2-43a0-85e4-ed74152e73b2}</Project>
       <Name>PeerCastStation.FLV</Name>
@@ -75,6 +79,10 @@
       <Project>{f9d126c6-76b7-45e2-b62e-6ac35ee285cd}</Project>
       <Name>PeerCastStation.PCP</Name>
     </ProjectReference>
+    <ProjectReference Include="..\PeerCastStation.TS\PeerCastStation.TS.csproj">
+      <Project>{0f0123ae-e500-45ca-b69d-4fbdbb88b752}</Project>
+      <Name>PeerCastStation.TS</Name>
+    </ProjectReference>
     <ProjectReference Include="..\PeerCastStation.UI.HTTP\PeerCastStation.UI.HTTP.csproj">
       <Project>{bf5e0b6d-961a-4216-bacf-01d80ab3d6bb}</Project>
       <Name>PeerCastStation.UI.HTTP</Name>
@@ -82,6 +90,10 @@
     <ProjectReference Include="..\PeerCastStation.UI\PeerCastStation.UI.csproj">
       <Project>{5988fbaf-37c4-4997-8389-55f2ebbb9511}</Project>
       <Name>PeerCastStation.UI</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\PeerCastStation.Updater\PeerCastStation.Updater.csproj">
+      <Project>{be5fd77b-d20e-40f6-b198-c7fd97e41274}</Project>
+      <Name>PeerCastStation.Updater</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/PeerCastStation/PeerCastStation.UI/Updater.cs
+++ b/PeerCastStation/PeerCastStation.UI/Updater.cs
@@ -99,6 +99,28 @@ namespace PeerCastStation.UI
       }
     }
 
+    static string ShellEscape(string arg)
+    {
+      if (arg.Contains(" ") && !arg.StartsWith("\"") && !arg.EndsWith("\"")) {
+        return "\"" + arg + "\"";
+      }
+      else {
+        return arg;
+      }
+    }
+
+    public static void ExecUpdater(string destpath, string filename)
+    {
+      var pid = System.Diagnostics.Process.GetCurrentProcess().Id;
+      var entry = System.IO.Path.GetFileName(Environment.GetCommandLineArgs()[0]);
+      var args = String.Join(" ", Environment.GetCommandLineArgs().Skip(1).Select(ShellEscape));
+
+      System.Diagnostics.Process.Start(
+        "PeerCastStation.Updater.exe",
+        $"{pid} {ShellEscape(filename)} {ShellEscape(destpath)} {ShellEscape(entry)} {args}"
+      );
+    }
+
     public static void InplaceUpdate(string destpath, string filename, string[] excludes)
     {
       destpath = System.IO.Path.GetFullPath(destpath);
@@ -200,10 +222,10 @@ namespace PeerCastStation.UI
         switch (downloaded.Enclosure.InstallerType) {
         case InstallerType.Archive:
         case InstallerType.ServiceArchive:
-          Updater.InplaceUpdate(
+          Updater.ExecUpdater(
             PeerCastApplication.Current.BasePath,
-            downloaded.FilePath,
-            new string[] { "PeerCastStation.exe", "PecaStationd.exe" });
+            downloaded.FilePath
+          );
           PeerCastApplication.Current.Stop(-1);
           break;
         case InstallerType.Installer:

--- a/PeerCastStation/PeerCastStation.Updater/App.config
+++ b/PeerCastStation/PeerCastStation.Updater/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+</configuration>

--- a/PeerCastStation/PeerCastStation.Updater/PeerCastStation.Updater.csproj
+++ b/PeerCastStation/PeerCastStation.Updater/PeerCastStation.Updater.csproj
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{BE5FD77B-D20E-40F6-B198-C7FD97E41274}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>PeerCastStation.Updater</RootNamespace>
+    <AssemblyName>PeerCastStation.Updater</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.IO.Compression" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/PeerCastStation/PeerCastStation.Updater/Program.cs
+++ b/PeerCastStation/PeerCastStation.Updater/Program.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PeerCastStation.Updater
+{
+  class Program
+  {
+    private static IEnumerable<string> Glob(string path)
+    {
+      try {
+        return
+          System.IO.Directory.GetFiles(path)
+          .Concat(
+            System.IO.Directory.GetDirectories(path).SelectMany(subpath => Glob(subpath)))
+          .Select(subpath => System.IO.Path.GetFullPath(subpath));
+      }
+      catch (Exception) {
+        return Enumerable.Empty<string>();
+      }
+    }
+
+    private static void InplaceUpdate(string destpath, string filename, string[] excludes)
+    {
+      destpath = System.IO.Path.GetFullPath(destpath);
+      using (var file = System.IO.File.OpenRead(filename))
+      using (var archive = new System.IO.Compression.ZipArchive(file, System.IO.Compression.ZipArchiveMode.Read)) {
+        var entries = archive.Entries.OrderBy(ent => ent.FullName);
+        var root = entries.First();
+        string rootpath = "";
+        if (root.FullName.EndsWith("/") &&
+            entries.All(ent => ent.FullName.StartsWith(root.FullName))) {
+          rootpath = root.FullName;
+        }
+        foreach (var ent in entries) {
+          var path = System.IO.Path.Combine(destpath, ent.FullName.Substring(rootpath.Length).Replace('/', '\\'));
+          if (ent.FullName.EndsWith("/")) {
+            var info = System.IO.Directory.CreateDirectory(path);
+            try {
+              info.LastWriteTime = ent.LastWriteTime.DateTime;
+            }
+            catch (System.IO.IOException) {
+            }
+          }
+          else {
+            try {
+              using (var dst = System.IO.File.OpenWrite(path))
+              using (var src = ent.Open()) {
+                src.CopyTo(dst);
+              }
+              var info = new System.IO.FileInfo(path);
+              try {
+                info.LastWriteTime = ent.LastWriteTime.DateTime;
+              }
+              catch (System.IO.IOException) {
+              }
+            }
+            catch (System.IO.IOException) {
+              if (!excludes.Contains(ent.Name)) throw;
+            }
+          }
+        }
+        var oldentries = Glob(destpath).ToArray();
+        var newentries = entries
+          .Select(ent => ent.FullName)
+          .Where(ent => !ent.EndsWith("/"))
+          .Select(ent => System.IO.Path.Combine(destpath, ent.Substring(rootpath.Length).Replace('/', '\\'))) 
+          .ToArray();
+        foreach (var old in oldentries.Except(newentries)) {
+          try {
+            System.IO.File.Delete(old);
+          }
+          catch (System.IO.IOException) {
+          }
+        }
+      }
+    }
+
+    static bool DoUpdate(string dest_dir, string source_path)
+    {
+      InplaceUpdate(dest_dir, source_path, new string[0]);
+      return true;
+    }
+
+    static string ShellEscape(string arg)
+    {
+      if (arg.Contains(" ") && !arg.StartsWith("\"") && !arg.EndsWith("\"")) {
+        return "\"" + arg + "\"";
+      }
+      else {
+        return arg;
+      }
+    }
+
+    static int Main(string[] args)
+    {
+      if (args.Length<4) {
+        System.Console.Error.WriteLine("USAGE: PeerCastStation.Updater.exe PID SOURCE.ZIP DESTDIR PEERCASTSTATION.EXE [ARGS...]");
+        return 1;
+      }
+
+      int parent_pid = 0;
+      if (!Int32.TryParse(args[0], out parent_pid)) {
+        System.Console.Error.WriteLine("USAGE: PeerCastStation.Updater.exe PID SOURCE.ZIP DESTDIR PEERCASTSTATION.EXE [ARGS...]");
+        return 1;
+      }
+      string source_path = args[1];
+      string dest_dir = System.IO.Path.GetFullPath(args[2]);
+      if (System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)==dest_dir) {
+        var path = System.IO.Path.Combine(
+          System.IO.Path.GetTempPath(),
+          "PeerCastStation.Updater.exe"
+        );
+        System.IO.File.Copy(System.Reflection.Assembly.GetExecutingAssembly().Location, path, true);
+        System.Diagnostics.Process.Start(path, String.Join(" ", args.Select(ShellEscape)));
+        return 0;
+      }
+
+      if (parent_pid!=0) {
+        try {
+          var process = System.Diagnostics.Process.GetProcessById(parent_pid);
+          process.WaitForExit(3000);
+        }
+        catch (ArgumentException) {
+          //Process not found
+        }
+        catch (SystemException) {
+          //Process not found
+        }
+      }
+
+      if (DoUpdate(dest_dir, source_path)) {
+        System.Diagnostics.Process.Start(System.IO.Path.Combine(dest_dir, args[3]), String.Join(" ", args.Skip(4)));
+        return 0;
+      }
+      else {
+        return 2;
+      }
+    }
+  }
+
+}

--- a/PeerCastStation/PeerCastStation.Updater/Properties/AssemblyInfo.cs
+++ b/PeerCastStation/PeerCastStation.Updater/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// アセンブリに関する一般情報は以下の属性セットをとおして制御されます。
+// アセンブリに関連付けられている情報を変更するには、
+// これらの属性値を変更してください。
+[assembly: AssemblyTitle("PeerCastStation.Updater")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("PeerCastStation.Updater")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// ComVisible を false に設定すると、このアセンブリ内の型は COM コンポーネントから
+// 参照できなくなります。COM からこのアセンブリ内の型にアクセスする必要がある場合は、
+// その型の ComVisible 属性を true に設定してください。
+[assembly: ComVisible(false)]
+
+// このプロジェクトが COM に公開される場合、次の GUID が typelib の ID になります
+[assembly: Guid("be5fd77b-d20e-40f6-b198-c7fd97e41274")]
+
+// アセンブリのバージョン情報は次の 4 つの値で構成されています:
+//
+//      メジャー バージョン
+//      マイナー バージョン
+//      ビルド番号
+//      Revision
+//
+// すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
+// 既定値にすることができます:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/PeerCastStation/PeerCastStation.WPF/Dialogs/UpdaterViewModel.cs
+++ b/PeerCastStation/PeerCastStation.WPF/Dialogs/UpdaterViewModel.cs
@@ -131,10 +131,9 @@ namespace PeerCastStation.WPF.Dialogs
         break;
       case ".zip":
         try {
-          Updater.InplaceUpdate(
+          Updater.ExecUpdater(
             PeerCastApplication.Current.BasePath,
-            downloadPath,
-            new string[] { "PeerCastStation.exe", "PecaStationd.exe" });
+            downloadPath);
           PeerCastApplication.Current.Stop(-1);
         }
         catch (Exception) {

--- a/PeerCastStation/PeerCastStation.sln
+++ b/PeerCastStation/PeerCastStation.sln
@@ -83,6 +83,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PeerCastStation.CustomFilte
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PeerCastStation.App", "PeerCastStation.App\PeerCastStation.App.csproj", "{C8B4E4DC-BE2B-4FC5-94D2-A22FF754C9A7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PeerCastStation.Updater", "PeerCastStation.Updater\PeerCastStation.Updater.csproj", "{BE5FD77B-D20E-40F6-B198-C7FD97E41274}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -172,6 +174,10 @@ Global
 		{C8B4E4DC-BE2B-4FC5-94D2-A22FF754C9A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C8B4E4DC-BE2B-4FC5-94D2-A22FF754C9A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C8B4E4DC-BE2B-4FC5-94D2-A22FF754C9A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE5FD77B-D20E-40F6-B198-C7FD97E41274}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE5FD77B-D20E-40F6-B198-C7FD97E41274}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE5FD77B-D20E-40F6-B198-C7FD97E41274}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE5FD77B-D20E-40F6-B198-C7FD97E41274}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/PeerCastStation/PeerCastStation/PeerCastStation.cs
+++ b/PeerCastStation/PeerCastStation/PeerCastStation.cs
@@ -12,7 +12,6 @@ namespace PeerCastStation.Main
       var result = StandaloneApp.Run(basepath, args);
       switch (result) {
       case -1:
-        //TODO:ダウンロードしたアップデートの位置をUpdaterに渡して起動する
         return 0;
       default:
         return result;

--- a/PeerCastStation/PeerCastStation/PeerCastStation.csproj
+++ b/PeerCastStation/PeerCastStation/PeerCastStation.csproj
@@ -106,6 +106,10 @@
       <Project>{5988fbaf-37c4-4997-8389-55f2ebbb9511}</Project>
       <Name>PeerCastStation.UI</Name>
     </ProjectReference>
+    <ProjectReference Include="..\PeerCastStation.Updater\PeerCastStation.Updater.csproj">
+      <Project>{be5fd77b-d20e-40f6-b198-c7fd97e41274}</Project>
+      <Name>PeerCastStation.Updater</Name>
+    </ProjectReference>
     <ProjectReference Include="..\PeerCastStation.WPF\PeerCastStation.WPF.csproj">
       <Project>{5ea68141-ac06-428b-9526-a6835e0cc2b2}</Project>
       <Name>PeerCastStation.WPF</Name>


### PR DESCRIPTION
アセンブリのシャドウコピーを別AppDomainから起動するようにして置き換えアップデートを実装していたが、
別AppDomainの起動はデバッグやCtrl+Cでの終了にいろいろと不都合が出るため取り止めて、
アップデートは別プロセスを起動して置き換えアップデートを実行するようにする。

## プロセスの再起動について
monoで元の引数を維持したまま再起動ができないものと思ってプロセスの再起動を伴わないシャドウコピーのAppDomain起動をやっていたが、monoではProcess.Startで.NETのexeを指定すると元のmonoの引数で勝手に起動してくれるようなので、プロセス再起動で問題がない模様。