### PR TITLE
起動プロセスが死んだ時にメインプロセスも死ぬようにした

### DIFF
--- a/PeerCastStation/PeerCastStation.App/OptionParser.cs
+++ b/PeerCastStation/PeerCastStation.App/OptionParser.cs
@@ -21,15 +21,15 @@ namespace PeerCastStation.App
     public OptionDesc(string optLong, string optShort, OptionArg arg)
     {
       LongName = optLong;
-      ShortName = optShort;
+      ShortName = optShort ?? optLong;
       Argument = arg;
       switch (Argument) {
       case OptionArg.None:
-        Regex = new System.Text.RegularExpressions.Regex($"^(?:{ShortName})|(?:{LongName})$");
+        Regex = new System.Text.RegularExpressions.Regex($"^(?:{ShortName}|{LongName})$");
         break;
       case OptionArg.Optional:
       case OptionArg.Required:
-        Regex = new System.Text.RegularExpressions.Regex($"^(?:{ShortName})|(?:{LongName})(?:=(.*))?$");
+        Regex = new System.Text.RegularExpressions.Regex($"^(?:{ShortName}|{LongName})(?:=(.*))?$");
         break;
       }
     }

--- a/PeerCastStation/PeerCastStation/PeerCastStation.cs
+++ b/PeerCastStation/PeerCastStation/PeerCastStation.cs
@@ -120,7 +120,7 @@ namespace PeerCastStation.Main
 
       int appresult;
       do {
-        appresult = InvokeApp("main", args);
+        appresult = InvokeApp("main", new string[] { $"--linkPID={System.Diagnostics.Process.GetCurrentProcess().Id}" }.Concat(args).ToArray());
         if (appresult==3) {
           using (var tmpdir=new TempDir("PeerCastStation.Updater")) {
             var updateresult = InvokeApp("update", tmpdir.Path);


### PR DESCRIPTION
終了させるのに起動プロセスだけ殺すツールがあったが、
メインプロセスが生き残ってしまって実質終了になっていなかったので、
メインプロセスは起動プロセスの終了を監視し、起動プロセスが終了した時にはメインプロセスも終了するようにした。

#358 への対応。