### PR TITLE
IPv6アドレスでの接続待ち受けでは明示的にIPv6Onlyの待ち受けをするようにした

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/OutputListener.cs
+++ b/PeerCastStation/PeerCastStation.Core/OutputListener.cs
@@ -174,6 +174,9 @@ namespace PeerCastStation.Core
         //Windows以外は明示的には付けないようにした。
         server.Server.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
       }
+      if (ip.AddressFamily==AddressFamily.InterNetworkV6) {
+        server.Server.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, true);
+      }
       server.Start(MaxPendingConnections);
       listenTask = StartListen(server, cancellationSource.Token);
     }

--- a/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPSourceStream.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPSourceStream.cs
@@ -131,7 +131,13 @@ namespace PeerCastStation.FLV.RTMP
         this.state = ConnectionState.Error;
         throw new BindErrorException(String.Format("Cannot resolve bind address: {0}", source.DnsSafeHost));
       }
-      var listeners = bind_addr.Select(addr => new TcpListener(addr)).ToArray();
+      var listeners = bind_addr.Select(addr => { 
+        var listener = new TcpListener(addr);
+        if (addr.AddressFamily==AddressFamily.InterNetworkV6) {
+          listener.Server.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, true);
+        }
+        return listener;
+      }).ToArray();
       try {
         var cancel_task = cancellationToken.CreateCancelTask<TcpClient>();
         var tasks = listeners.Select(listener => {

--- a/PeerCastStation/PeerCastStation.HTTP/HTTPPushSourceStream.cs
+++ b/PeerCastStation/PeerCastStation.HTTP/HTTPPushSourceStream.cs
@@ -123,7 +123,13 @@ namespace PeerCastStation.HTTP
         this.state = ConnectionState.Error;
         throw new BindErrorException(String.Format("Cannot resolve bind address: {0}", source.DnsSafeHost));
       }
-      var listeners = bind_addr.Select(addr => new TcpListener(addr)).ToArray();
+      var listeners = bind_addr.Select(addr => { 
+        var listener = new TcpListener(addr);
+        if (addr.AddressFamily==AddressFamily.InterNetworkV6) {
+          listener.Server.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, true);
+        }
+        return listener;
+      }).ToArray();
       try {
         var cancel_task = cancellationToken.CreateCancelTask<TcpClient>();
         var tasks = listeners.Select(listener => {


### PR DESCRIPTION
プラットフォームによってはIPv6アドレスで接続待ち受けするとIPv4のアドレスでも接続待ち受けをしてしまうのがデフォルトで有効になっているので、IPv6Onlyを明示的につけてIPv6のみで待ち受けるようにした。