### PR TITLE
帯域計測の精度を上げる

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/BandwidthChecker.cs
+++ b/PeerCastStation/PeerCastStation.Core/BandwidthChecker.cs
@@ -1,107 +1,163 @@
 ﻿using System;
 using System.Net;
 using System.Linq;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using System.Net.Security;
+using System.IO;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Threading;
 
 namespace PeerCastStation.Core
 {
-  public class BandwidthCheckCompletedEventArgs
-    : EventArgs
+  public struct BandwidthCheckResult
   {
-    public bool     Success     { get; private set; }
-    public int      DataSize    { get; private set; }
-    public TimeSpan ElapsedTime { get; private set; }
+    public bool     Succeeded;
+    public int      DataSize;
+    public TimeSpan ElapsedTime;
     public int Bitrate {
-      get { return (int)(DataSize*8 / Math.Max(ElapsedTime.TotalSeconds, 0.001)); }
-    }
-
-    public BandwidthCheckCompletedEventArgs(bool success, int data_size, TimeSpan elapsed)
-      : base()
-    {
-      this.Success     = success;
-      this.DataSize    = data_size;
-      this.ElapsedTime = elapsed;
+      get { return (int)(DataSize*8 / ElapsedTime.TotalSeconds); }
     }
   }
-  public delegate void BandwidthCheckCompletedEventHandler(object sender, BandwidthCheckCompletedEventArgs args);
 
   public class BandwidthChecker
   {
-    public static readonly int DataSize = 256*1024;
-    public static readonly int Tries    = 4;
     public Uri Target { get; private set; }
-    public BandwidthChecker(Uri target_uri)
+    public AddressFamily AddressFamily { get; private set; }
+    public BandwidthChecker(Uri target_uri, NetworkType networkType)
     {
       this.Target = target_uri;
+      switch (networkType) {
+      case NetworkType.IPv4:
+        this.AddressFamily = AddressFamily.InterNetwork;
+          break;
+      case NetworkType.IPv6:
+        this.AddressFamily = AddressFamily.InterNetworkV6;
+        break;
+      }
     }
 
-    private struct BandwidthCheckResult
+    private byte[] CreateChunk(byte[] data)
     {
-      public bool     Succeeded;
-      public TimeSpan ElapsedTime;
+      var prefix = System.Text.Encoding.ASCII.GetBytes($"{data.Length.ToString("X")}\r\n");
+      var postfix = System.Text.Encoding.ASCII.GetBytes("\r\n");
+      var chunked_data = new byte[prefix.Length+data.Length+postfix.Length];
+      Buffer.BlockCopy(prefix, 0, chunked_data, 0, prefix.Length);
+      Buffer.BlockCopy(data, 0, chunked_data, prefix.Length, data.Length);
+      Buffer.BlockCopy(postfix, 0, chunked_data, prefix.Length+data.Length, postfix.Length);
+      return chunked_data;
     }
 
-    public void RunAsync()
+    private async Task<byte[]> PostAsync(Func<Stream,CancellationToken,Task> post_body, CancellationToken cancellationToken)
     {
-      var ctx = System.Threading.SynchronizationContext.Current;
-      System.Threading.ThreadPool.QueueUserWorkItem(state => {
-        var client = new WebClient();
-        var rand   = new Random();
-        var data   = new byte[DataSize];
-        rand.NextBytes(data);
-        var results = new BandwidthCheckResult[Tries];
-        for (var i=0; i<Tries; i++) {
-          try {
-            var stopwatch = new System.Diagnostics.Stopwatch();
-            stopwatch.Start();
-            var response_body = client.UploadData(Target, data);
-            stopwatch.Stop();
-            results[i].ElapsedTime = stopwatch.Elapsed;
-            results[i].Succeeded = true;
-          }
-          catch (WebException) {
-            results[i].Succeeded = false;
-          }
+      var targetAddress =
+        (await Dns.GetHostAddressesAsync(Target.DnsSafeHost).ConfigureAwait(false))
+          .Where(addr => addr.AddressFamily==AddressFamily)
+          .FirstOrDefault();
+      if (targetAddress==null) throw new WebException();
+      using (var client=new TcpClient(AddressFamily)) {
+        client.NoDelay = true;
+        client.ReceiveBufferSize = 256*1024;
+        client.SendBufferSize = 256*1024;
+        await client.ConnectAsync(targetAddress, Target.Port).ConfigureAwait(false);
+        Stream stream = client.GetStream();
+        if (Target.Scheme=="https") {
+          var ssl = new SslStream(stream);
+          stream = ssl;
+          await ssl.AuthenticateAsClientAsync(Target.DnsSafeHost).ConfigureAwait(false);
         }
-        if (BandwidthCheckCompleted!=null) {
-          var success = results.Count(r => r.Succeeded)>0;
-          var average_seconds = results.Average(r => r.ElapsedTime.TotalSeconds);
-          ctx.Post(s => {
-            BandwidthCheckCompleted(
-              this,
-              new BandwidthCheckCompletedEventArgs(success, DataSize, TimeSpan.FromSeconds(average_seconds)));
-          }, null);
+        var req = System.Text.Encoding.ASCII.GetBytes(
+          $"POST {Target.PathAndQuery} HTTP/1.1\r\n" +
+          $"Host:{Target.DnsSafeHost}\r\n" +
+          $"User-Agent:PeerCastStation\r\n" +
+          $"Connection:close\r\n" +
+          $"Accept:application/json\r\n" +
+          $"Accept-Encoding:\r\n" +
+          $"Content-Type:application/octet-stream\r\n" +
+          $"Transfer-Encoding:chunked\r\n" +
+          "\r\n");
+        await stream.WriteBytesAsync(req, cancellationToken).ConfigureAwait(false);
+        await post_body(stream, cancellationToken).ConfigureAwait(false);
+        await stream.WriteBytesAsync(CreateChunk(new byte[0]), cancellationToken).ConfigureAwait(false);
+
+        using (var bufStream=new BufferedStream(stream, 8192)) {
+          string line = null;
+          var responses = new List<string>();
+          var buf = new List<byte>(8192);
+          while (line!="") {
+            var value = await bufStream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
+            if (value<0) throw new WebException();
+            buf.Add((byte)value);
+            if (buf.Count>=2 && buf[buf.Count-2]=='\r' && buf[buf.Count-1]=='\n') {
+              line = System.Text.Encoding.ASCII.GetString(buf.ToArray(), 0, buf.Count-2);
+              if (line!="") responses.Add(line);
+              buf.Clear();
+            }
+          }
+          var statusLine = responses.FirstOrDefault();
+          if (statusLine==null) throw new WebException();
+          var match = Regex.Match(statusLine, @"^HTTP/1.\d (\d+) .*$", RegexOptions.IgnoreCase);
+          if (!match.Success) throw new WebException();
+          var status = Int32.Parse(match.Groups[1].Value);
+          if (status!=200) throw new WebException();
+          var headers =
+            responses
+            .Skip(1)
+            .Select(ln => {
+              var sep = ln.IndexOf(':');
+              if (sep<0) {
+                return new KeyValuePair<string,string>(ln, "");
+              }
+              else {
+                return new KeyValuePair<string,string>(ln.Substring(0, sep), ln.Substring(sep+1));
+              }
+            })
+            .ToDictionary(kv => kv.Key.ToUpperInvariant(), kv => kv.Value);
+          //var content_length = Int32.Parse(headers["CONTENT-LENGTH"]);
+          //return await bufStream.ReadBytesAsync(content_length, ct);
+          return new byte[0];
         }
-      });
+      }
     }
 
-    public void Run()
+    public async Task<BandwidthCheckResult> RunAsync(CancellationToken cancellationToken)
     {
-      var client = new WebClient();
-      var rand   = new Random();
-      var data   = new byte[DataSize];
+      var result = new BandwidthCheckResult {
+        Succeeded = false,
+        DataSize = 0,
+        ElapsedTime = TimeSpan.MaxValue,
+      };
+      var rand = new Random();
+      var data = new byte[250*1024];
       rand.NextBytes(data);
-      var results = new BandwidthCheckResult[Tries];
-      for (var i=0; i<Tries; i++) {
-        try {
-          var stopwatch = new System.Diagnostics.Stopwatch();
-          stopwatch.Start();
-          var response_body = client.UploadData(Target, data);
-          stopwatch.Stop();
-          results[i].ElapsedTime = stopwatch.Elapsed;
-          results[i].Succeeded = true;
-        }
-        catch (WebException) {
-          results[i].Succeeded = false;
-        }
+      data = CreateChunk(data);
+      var stopwatch = new System.Diagnostics.Stopwatch();
+      try {
+        int sz = 0;
+        stopwatch.Start();
+        await PostAsync(async (s, ct) => {
+          while (stopwatch.ElapsedMilliseconds<10000) {
+            await s.WriteBytesAsync(data, ct).ConfigureAwait(false);
+            sz += data.Length;
+          }
+        }, cancellationToken).ConfigureAwait(false);
+        stopwatch.Stop();
+        result.DataSize = sz;
+        result.Succeeded = true;
+        result.ElapsedTime = stopwatch.Elapsed;
       }
-      if (BandwidthCheckCompleted!=null) {
-        var success = results.Count(r => r.Succeeded)>0;
-        var average_seconds = results.Average(r => r.ElapsedTime.TotalSeconds);
-        BandwidthCheckCompleted(this, new BandwidthCheckCompletedEventArgs(success, DataSize, TimeSpan.FromSeconds(average_seconds)));
+      catch (WebException) {
+        result.Succeeded = false;
       }
+      return result;
     }
 
-    public event BandwidthCheckCompletedEventHandler BandwidthCheckCompleted;
+    public BandwidthCheckResult Run()
+    {
+      return RunAsync(CancellationToken.None).Result;
+    }
   }
 
 }
+

--- a/PeerCastStation/PeerCastStation.Core/StreamExtension.cs
+++ b/PeerCastStation/PeerCastStation.Core/StreamExtension.cs
@@ -73,6 +73,11 @@ namespace PeerCastStation.Core
       return stream.WriteAsync(new byte[] { value }, 0, 1, cancel_token);
     }
 
+    public static Task WriteBytesAsync(this Stream stream, byte[] data, CancellationToken cancel_token)
+    {
+      return stream.WriteAsync(data, 0, data.Length);
+    }
+
     static public void Write(this Stream stream, Atom atom)
     {
       var name = atom.Name.GetBytes();

--- a/PeerCastStation/PeerCastStation.UI.HTTP/APIHost.cs
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/APIHost.cs
@@ -1204,7 +1204,8 @@ namespace PeerCastStation.UI.HTTP
       {
         int? result = null;
         string uri_key;
-        switch (ParseNetworkType(networkType)) {
+        var network = ParseNetworkType(networkType);
+        switch (network) {
         case NetworkType.IPv6:
           uri_key = "BandwidthCheckerV6";
           break;
@@ -1215,13 +1216,11 @@ namespace PeerCastStation.UI.HTTP
         }
         Uri target_uri;
         if (AppSettingsReader.TryGetUri(uri_key, out target_uri)) {
-          var checker = new BandwidthChecker(target_uri);
-          checker.BandwidthCheckCompleted += (sender, args) => {
-            if (args.Success) {
-              result = (int)args.Bitrate/1000;
-            }
-          };
-          checker.Run();
+          var checker = new BandwidthChecker(target_uri, network);
+          var res = checker.Run();
+          if (res.Succeeded) {
+            result = (int)res.Bitrate/1000;
+          }
         }
         return result;
       }


### PR DESCRIPTION
既定サイズのデータを送る時間によって帯域を計測していたが、十分な速度が出る場合にはデータ量が少ないと精度が怪しく、データ量を多くしすぎると細い回線で時間がかかりすぎてしまっていた。
そのため約10秒間に送れたデータ量によって帯域を計測するように変更した。