### PR TITLE
視聴URLを開く時のプロトコルを指定できるようにした。

### DIFF
--- a/PeerCastStation/PeerCastStation.UI.HTTP/APIHost.cs
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/APIHost.cs
@@ -23,6 +23,7 @@ namespace PeerCastStation.UI.HTTP
     private Updater updater = new Updater();
     private IEnumerable<VersionDescription> newVersions = Enumerable.Empty<VersionDescription>();
     private OWINApplication application;
+    private object locker = new object();
 
     private ObjectIdRegistry idRegistry = new ObjectIdRegistry();
     override protected void OnAttach()
@@ -56,6 +57,18 @@ namespace PeerCastStation.UI.HTTP
 
     protected override void OnDetach()
     {
+    }
+
+    private Task saveSettingsTask = Task.Delay(0);
+    private void SaveSettings()
+    {
+      lock (locker) {
+        if (!saveSettingsTask.IsCompleted) return;
+        saveSettingsTask =
+          Task.Delay(100).ContinueWith(_ => {
+            Application.SaveSettings();
+          });
+      }
     }
 
     void OnNewVersionFound(object sender, NewVersionFoundEventArgs args)
@@ -437,7 +450,7 @@ namespace PeerCastStation.UI.HTTP
             port_mapper.DiscoverAsync();
           }
         });
-        owner.Application.SaveSettings();
+        owner.SaveSettings();
       }
 
       [RPCMethod("getLogSettings")]
@@ -453,7 +466,7 @@ namespace PeerCastStation.UI.HTTP
       {
         settings.TryGetThen("level", v => {
           Logger.Level = (LogLevel)v;
-          owner.Application.SaveSettings();
+          owner.SaveSettings();
         });
       }
 
@@ -877,7 +890,7 @@ namespace PeerCastStation.UI.HTTP
 					throw new RPCError(RPCErrorCode.InvalidParams, "Invalid uri");
 				}
         var yp = PeerCast.AddYellowPage(factory.Protocol, name, announce_uri, channels_uri);
-        owner.Application.SaveSettings();
+        owner.SaveSettings();
         var res = new JObject();
         res["yellowPageId"] = GetObjectId(yp);
         res["name"]         = yp.Name;
@@ -894,7 +907,7 @@ namespace PeerCastStation.UI.HTTP
         var yp = PeerCast.YellowPages.FirstOrDefault(p => GetObjectId(p)==yellowPageId);
         if (yp!=null) {
           PeerCast.RemoveYellowPage(yp);
-          owner.Application.SaveSettings();
+          owner.SaveSettings();
         }
       }
 
@@ -1002,7 +1015,7 @@ namespace PeerCastStation.UI.HTTP
         listener = PeerCast.StartListen(endpoint, (OutputStreamType)localAccepts, (OutputStreamType)globalAccepts);
         listener.LocalAuthorizationRequired  = localAuthorizationRequired;
         listener.GlobalAuthorizationRequired = globalAuthorizationRequired;
-        owner.Application.SaveSettings();
+        owner.SaveSettings();
         return GetListener(listener);
       }
 
@@ -1011,7 +1024,7 @@ namespace PeerCastStation.UI.HTTP
       {
         var listener = PeerCast.OutputListeners.Where(ol => GetObjectId(ol)==listenerId).FirstOrDefault();
         if (listener!=null) {
-          owner.Application.SaveSettings();
+          owner.SaveSettings();
           listener.ResetAuthenticationKey();
           return GetListener(listener);
         }
@@ -1026,7 +1039,7 @@ namespace PeerCastStation.UI.HTTP
         foreach (var listener in PeerCast.OutputListeners.Where(ol => GetObjectId(ol)==listenerId)) {
           PeerCast.StopListen(listener);
         }
-        owner.Application.SaveSettings();
+        owner.SaveSettings();
       }
 
       [RPCMethod("setListenerAccepts")]
@@ -1036,7 +1049,7 @@ namespace PeerCastStation.UI.HTTP
           listener.LocalOutputAccepts = (OutputStreamType)localAccepts;
           listener.GlobalOutputAccepts = (OutputStreamType)globalAccepts;
         }
-        owner.Application.SaveSettings();
+        owner.SaveSettings();
       }
 
       [RPCMethod("setListenerAuthorizationRequired")]
@@ -1046,7 +1059,7 @@ namespace PeerCastStation.UI.HTTP
           listener.LocalAuthorizationRequired = localAuthorizationRequired;
           listener.GlobalAuthorizationRequired = globalAuthorizationRequired;
         }
-        owner.Application.SaveSettings();
+        owner.SaveSettings();
       }
 
       [RPCMethod("broadcastChannel")]
@@ -1384,32 +1397,73 @@ namespace PeerCastStation.UI.HTTP
 				return YPChannelsToArray(owner.UpdateYPChannels());
 			}
 
-			[RPCMethod("setUserConfig")]
-			public void SetUserConfig(string user, string key, JObject value)
-			{
-				var settings = owner.Application.Settings.Get<UISettings>();
-				Dictionary<string, string> user_config;
-				if (!settings.UserConfig.TryGetValue(user, out user_config)) {
-					user_config = new Dictionary<string, string>();
-					settings.UserConfig[user] = user_config;
-				}
-				user_config[key] = value.ToString();
-				owner.Application.SaveSettings();
-			}
+      private bool TrySetUIConfig(UISettings settings, string key, JObject value)
+      {
+        switch (key) {
+        case "defaultPlayProtocol":
+          settings.DefaultPlayProtocols =
+            value
+            .Properties()
+            .ToDictionary(
+              prop => prop.Name,
+              prop => Enum.TryParse<PlayProtocol>(prop.Value.ToString(), out var v) ? v : PlayProtocol.Unknown
+            );
+          return true;
+        default:
+          return false;
+        }
+      }
 
-			[RPCMethod("getUserConfig")]
-			public JToken GetUserConfig(string user, string key)
-			{
-				var settings = owner.Application.Settings.Get<UISettings>();
-				Dictionary<string, string> user_config;
-				if (!settings.UserConfig.TryGetValue(user, out user_config)) {
-					return null;
-				}
-				if (!user_config.ContainsKey(key)) {
-					return null;
-				}
-				return JToken.Parse(user_config[key]);
-			}
+      [RPCMethod("setUserConfig")]
+      public void SetUserConfig(string user, string key, JObject value)
+      {
+        var settings = owner.Application.Settings.Get<UISettings>();
+        if (!TrySetUIConfig(settings, key, value)) {
+          Dictionary<string, string> user_config;
+          if (!settings.UserConfig.TryGetValue(user, out user_config)) {
+            user_config = new Dictionary<string, string>();
+            settings.UserConfig[user] = user_config;
+          }
+          user_config[key] = value.ToString();
+        }
+        owner.SaveSettings();
+      }
+
+      private bool TryGetUIConfig(UISettings settings, string key, out JToken value)
+      {
+        switch (key) {
+        case "defaultPlayProtocol":
+          {
+            var obj = new JObject();
+            foreach (var kv in settings.DefaultPlayProtocols) {
+              obj[kv.Key] = kv.Value.ToString();
+            }
+            value = obj;
+            return true;
+          }
+        default:
+          value = null;
+          return false;
+        }
+      }
+
+      [RPCMethod("getUserConfig")]
+      public JToken GetUserConfig(string user, string key)
+      {
+        var settings = owner.Application.Settings.Get<UISettings>();
+        if (TryGetUIConfig(settings, key, out var value)) {
+          return value;
+        }
+        else {
+          if (settings.UserConfig.TryGetValue(user, out var user_config) &&
+              user_config.TryGetValue(key, out var str)) {
+            return JToken.Parse(str);
+          }
+          else {
+            return null;
+          }
+        }
+      }
 
     }
 

--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/settings.html
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/settings.html
@@ -245,6 +245,20 @@
                 </select>
               </div>
             </div>
+
+            <div class="ui-row">
+              <div class="ui-header">視聴方法</div>
+              <div class="ui-label">FLV: </div>
+              <div class="ui-control">
+                <select data-bind="value:defaultPlayProtocolFLV">
+                  <option value="Unknown">既定</option>
+                  <option value="HTTP">HTTP</option>
+                  <option value="RTMP">RTMP</option>
+                  <option value="HLS">HTTP Live Streaming</option>
+                </select>
+              </div>
+            </div>
+
           </div>
         </div>
       </div>

--- a/PeerCastStation/PeerCastStation.UI/UISettings.cs
+++ b/PeerCastStation/PeerCastStation.UI/UISettings.cs
@@ -5,6 +5,15 @@ using System.Linq;
 namespace PeerCastStation.UI
 {
   [PeerCastStation.Core.PecaSettings]
+  public enum PlayProtocol {
+    Unknown = 0,
+    HTTP,
+    MSWMSP,
+    HLS,
+    RTMP,
+  }
+
+  [PeerCastStation.Core.PecaSettings]
   public class UISettings
   {
     private BroadcastInfo[] broadcastHistory = new BroadcastInfo[0];
@@ -12,6 +21,8 @@ namespace PeerCastStation.UI
       get { return broadcastHistory; }
       set { broadcastHistory = value; }
     }
+
+    public Dictionary<string, PlayProtocol> DefaultPlayProtocols { get; set; } = new Dictionary<string, PlayProtocol>();
 
 		public Dictionary<string, Dictionary<string, string>> UserConfig { get; set; }
 

--- a/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingControl.xaml
+++ b/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingControl.xaml
@@ -496,20 +496,33 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. -->
       <TabItem Header="UI設定">
         <ScrollViewer VerticalScrollBarVisibility="Auto">
           <Grid Margin="3">
-          <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-          </Grid.RowDefinitions>
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto"/>
-            <ColumnDefinition Width="*"/>
-          </Grid.ColumnDefinitions>
-          <CheckBox Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="0" Margin="2" Content="起動時にウィンドウを表示する" IsChecked="{Binding IsShowWindowOnStartup}"/>
-          <CheckBox Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="1" Margin="2" Content="通知を表示する" IsChecked="{Binding IsShowNotifications}"/>
-          <Label    Grid.Column="0" Grid.Row="2" Content="接続先表示:"/>
-          <ComboBox Grid.Column="1" Grid.Row="2" Margin="2" ItemsSource="{Binding RemoteNodeNameItems}" DisplayMemberPath="Item1" SelectedValuePath="Item2" IsEditable="False" SelectedValue="{Binding RemoteNodeName}"/>
-        </Grid>
+            <Grid.RowDefinitions>
+              <RowDefinition Height="Auto"/>
+              <RowDefinition Height="Auto"/>
+              <RowDefinition Height="Auto"/>
+              <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="Auto"/>
+              <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <CheckBox Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="0" Margin="2" Content="起動時にウィンドウを表示する" IsChecked="{Binding IsShowWindowOnStartup}"/>
+            <CheckBox Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="1" Margin="2" Content="通知を表示する" IsChecked="{Binding IsShowNotifications}"/>
+            <Label    Grid.Column="0" Grid.Row="2" Content="接続先表示:"/>
+            <ComboBox Grid.Column="1" Grid.Row="2" Margin="2" ItemsSource="{Binding RemoteNodeNameItems}" DisplayMemberPath="Name" SelectedValuePath="Value" IsEditable="False" SelectedValue="{Binding RemoteNodeName}"/>
+            <Label    Grid.Column="0" Grid.Row="3" Content="視聴方法:"/>
+            <Grid Grid.Column="1" Grid.Row="3">
+              <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+              </Grid.RowDefinitions>
+              <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+              </Grid.ColumnDefinitions>
+              <Label Grid.Column="0" Grid.Row="0" Content="FLV:"/>
+              <ComboBox Grid.Column="1" Grid.Row="0" Margin="2" ItemsSource="{Binding PlayProtocols[FLV]}" DisplayMemberPath="Name" SelectedValuePath="Value" IsEditable="False" SelectedValue="{Binding DefaultPlayProtocols[FLV]}"/>
+            </Grid>
+          </Grid>
         </ScrollViewer>
       </TabItem>
     </TabControl>

--- a/PeerCastStation/PeerCastStation.WPF/DictionaryExtension.cs
+++ b/PeerCastStation/PeerCastStation.WPF/DictionaryExtension.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace PeerCastStation.WPF
+{
+  internal static class DictionaryExtension
+  {
+    internal class DictionaryWithDefaultValue<TKey, TValue>
+      : IDictionary<TKey, TValue>
+      , IReadOnlyDictionary<TKey, TValue>
+    {
+      public IDictionary<TKey,TValue> BaseDictionary { get; private set; }
+      public Func<TKey,TValue> DefaultValue { get; private set; }
+      public DictionaryWithDefaultValue(IDictionary<TKey,TValue> dic, Func<TKey,TValue> defaultValueFunc)
+      {
+        BaseDictionary = dic;
+        DefaultValue = defaultValueFunc;
+      }
+
+      public TValue this[TKey key] {
+        get {
+          if (BaseDictionary.TryGetValue(key, out var value)) {
+            return value;
+          }
+          else {
+            return DefaultValue(key);
+          }
+        }
+        set { BaseDictionary[key] = value; }
+      }
+
+      public ICollection<TKey> Keys {
+        get { return BaseDictionary.Keys; }
+      }
+
+      public ICollection<TValue> Values {
+        get { return BaseDictionary.Values; }
+      }
+
+      public int Count {
+        get { return BaseDictionary.Count; }
+      }
+
+      public bool IsReadOnly {
+        get { return BaseDictionary.IsReadOnly; }
+      }
+
+      IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys {
+        get { return ((IReadOnlyDictionary<TKey,TValue>)BaseDictionary).Keys; }
+      }
+
+      IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values {
+        get { return ((IReadOnlyDictionary<TKey,TValue>)BaseDictionary).Values; }
+      }
+
+      public void Add(TKey key, TValue value)
+      {
+        BaseDictionary.Add(key, value);
+      }
+
+      public void Add(KeyValuePair<TKey, TValue> item)
+      {
+        BaseDictionary.Add(item);
+      }
+
+      public void Clear()
+      {
+        BaseDictionary.Clear();
+      }
+
+      public bool Contains(KeyValuePair<TKey, TValue> item)
+      {
+        return BaseDictionary.Contains(item);
+      }
+
+      public bool ContainsKey(TKey key)
+      {
+        return BaseDictionary.ContainsKey(key);
+      }
+
+      public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+      {
+        BaseDictionary.CopyTo(array, arrayIndex);
+      }
+
+      public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+      {
+        return BaseDictionary.GetEnumerator();
+      }
+
+      public bool Remove(TKey key)
+      {
+        return BaseDictionary.Remove(key);
+      }
+
+      public bool Remove(KeyValuePair<TKey, TValue> item)
+      {
+        return BaseDictionary.Remove(item);
+      }
+
+      public bool TryGetValue(TKey key, out TValue value)
+      {
+        return BaseDictionary.TryGetValue(key, out value);
+      }
+
+      IEnumerator IEnumerable.GetEnumerator()
+      {
+        return ((IEnumerable)BaseDictionary).GetEnumerator();
+      }
+    }
+
+    public static IDictionary<TKey,TValue> WithDefaultValue<TKey,TValue>(this IDictionary<TKey,TValue> dic)
+    {
+      return new DictionaryWithDefaultValue<TKey,TValue>(dic, key => default(TValue));
+    }
+
+    public static IDictionary<TKey,TValue> WithDefaultValue<TKey,TValue>(this IDictionary<TKey,TValue> dic, Func<TKey,TValue> defaultValueFunc)
+    {
+      return new DictionaryWithDefaultValue<TKey,TValue>(dic, defaultValueFunc);
+    }
+
+  }
+
+}
+

--- a/PeerCastStation/PeerCastStation.WPF/NamedValueList.cs
+++ b/PeerCastStation/PeerCastStation.WPF/NamedValueList.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PeerCastStation.WPF
+{
+  internal class NamedValue<T>
+  {
+    public string Name { get; private set; }
+    public T Value { get; private set; }
+    public NamedValue(string name, T value)
+    {
+      Name = name;
+      Value = value;
+    }
+  }
+
+  internal class NamedValueList<T>
+    : List<NamedValue<T>>
+  {
+    public void Add(string name, T value)
+    {
+      Add(new NamedValue<T>(name, value));
+    }
+  }
+
+}

--- a/PeerCastStation/PeerCastStation.WPF/ObservableDictionary.cs
+++ b/PeerCastStation/PeerCastStation.WPF/ObservableDictionary.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PeerCastStation.WPF
+{
+  internal class NotifyItemChangedEventArgs<TKey>
+    : EventArgs
+  {
+    public TKey Key { get; private set; }
+    public NotifyItemChangedEventArgs(TKey key)
+    {
+      Key = key;
+    }
+  }
+
+  internal delegate void NotifyItemChangedEventHandler<TKey>(object sender, NotifyItemChangedEventArgs<TKey> args);
+
+  internal interface INotifyItemChanged<TKey>
+  {
+    event NotifyItemChangedEventHandler<TKey> ItemChanged;
+  }
+
+  internal class ObservableDictionary<TKey, TValue>
+    : IDictionary<TKey, TValue>
+    , IReadOnlyDictionary<TKey, TValue>
+    , INotifyItemChanged<TKey>
+  {
+    public IDictionary<TKey, TValue> Base { get; private set; }
+    public TValue this[TKey key] {
+      get { return Base[key]; }
+      set {
+        Base[key] = value;
+        ItemChanged?.Invoke(this, new NotifyItemChangedEventArgs<TKey>(key));
+      }
+    }
+
+    public ICollection<TKey> Keys {
+      get { return Base.Keys; }
+    }
+
+    public ICollection<TValue> Values {
+      get { return Base.Values; }
+    }
+
+    public int Count {
+      get { return Base.Count; }
+    }
+
+    public bool IsReadOnly {
+      get { return Base.IsReadOnly; }
+    }
+
+    IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys {
+      get { return Base.Keys; }
+    }
+
+    IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values {
+      get { return Base.Values; }
+    }
+
+    public event NotifyItemChangedEventHandler<TKey> ItemChanged;
+
+    public ObservableDictionary(IDictionary<TKey, TValue> dic)
+    {
+      Base = dic;
+    }
+
+    public ObservableDictionary()
+    {
+      Base = new Dictionary<TKey, TValue>();
+    }
+
+    public void Add(TKey key, TValue value)
+    {
+      Base.Add(key, value);
+      ItemChanged?.Invoke(this, new NotifyItemChangedEventArgs<TKey>(key));
+    }
+
+    public void Add(KeyValuePair<TKey, TValue> item)
+    {
+      Base.Add(item);
+      ItemChanged?.Invoke(this, new NotifyItemChangedEventArgs<TKey>(item.Key));
+    }
+
+    public void Clear()
+    {
+      var keys = Base.Keys.ToArray();
+      Base.Clear();
+      foreach (var key in keys) {
+        ItemChanged?.Invoke(this, new NotifyItemChangedEventArgs<TKey>(key));
+      }
+    }
+
+    public bool Contains(KeyValuePair<TKey, TValue> item)
+    {
+      return Base.Contains(item);
+    }
+
+    public bool ContainsKey(TKey key)
+    {
+      return Base.ContainsKey(key);
+    }
+
+    public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+    {
+      Base.CopyTo(array, arrayIndex);
+    }
+
+    public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+    {
+      return Base.GetEnumerator();
+    }
+
+    public bool Remove(TKey key)
+    {
+      if (Base.Remove(key)) {
+        ItemChanged?.Invoke(this, new NotifyItemChangedEventArgs<TKey>(key));
+        return true;
+      }
+      else {
+        return false;
+      }
+    }
+
+    public bool Remove(KeyValuePair<TKey, TValue> item)
+    {
+      if (Base.Remove(item)) {
+        ItemChanged?.Invoke(this, new NotifyItemChangedEventArgs<TKey>(item.Key));
+        return true;
+      }
+      else {
+        return false;
+      }
+    }
+
+    public bool TryGetValue(TKey key, out TValue value)
+    {
+      return Base.TryGetValue(key, out value);
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+      return Base.GetEnumerator();
+    }
+  }
+
+}

--- a/PeerCastStation/PeerCastStation.WPF/PeerCastStation.WPF.csproj
+++ b/PeerCastStation/PeerCastStation.WPF/PeerCastStation.WPF.csproj
@@ -63,9 +63,12 @@
     <Compile Include="CoreSettings\BandwidthCheckDialog.xaml.cs">
       <DependentUpon>BandwidthCheckDialog.xaml</DependentUpon>
     </Compile>
+    <Compile Include="DictionaryExtension.cs" />
     <Compile Include="LogWindow.xaml.cs">
       <DependentUpon>LogWindow.xaml</DependentUpon>
     </Compile>
+    <Compile Include="NamedValueList.cs" />
+    <Compile Include="ObservableDictionary.cs" />
     <Compile Include="PeerCastCommands.cs" />
     <Compile Include="ChannelConnectionViewModel.cs" />
     <Compile Include="ChannelLists\ConnectionLists\ConnectionListViewModel.cs" />

--- a/PeerCastStation/PeerCastStation.WPF/UISettingsViewModel.cs
+++ b/PeerCastStation/PeerCastStation.WPF/UISettingsViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using PeerCastStation.Core;
+using PeerCastStation.UI;
 
 namespace PeerCastStation.WPF
 {
@@ -11,13 +12,14 @@ namespace PeerCastStation.WPF
     : INotifyPropertyChanged
   {
     public ObservableCollection<BroadcastInfoViewModel> BroadcastHistory { get; private set; }
+    public PlayProtocol FLVPlayProtocol { get; set; }
 
     private PeerCastStation.Core.PecaSettings settings;
     public UISettingsViewModel(PeerCastStation.Core.PecaSettings settings)
     {
       this.settings = settings;
       var wpf = settings.Get<WPFSettings>();
-      var ui = settings.Get<PeerCastStation.UI.UISettings>();
+      var ui = settings.Get<UISettings>();
       if (ui.BroadcastHistory.Length>0) {
         BroadcastHistory = new ObservableCollection<BroadcastInfoViewModel>(
           ui.BroadcastHistory.Select(info => new BroadcastInfoViewModel(info)));
@@ -26,13 +28,20 @@ namespace PeerCastStation.WPF
         BroadcastHistory = new ObservableCollection<BroadcastInfoViewModel>(
           wpf.BroadcastHistory.Select(info => new BroadcastInfoViewModel(info)));
       }
+      if (ui.DefaultPlayProtocols.TryGetValue("FLV", out var protocol)) {
+        FLVPlayProtocol = protocol;
+      }
+      else {
+        FLVPlayProtocol = PlayProtocol.Unknown;
+      }
     }
 
     public void Save()
     {
       var wpf = settings.Get<WPFSettings>();
-      var ui = settings.Get<PeerCastStation.UI.UISettings>();
+      var ui = settings.Get<UISettings>();
       ui.BroadcastHistory = BroadcastHistory.Select(info => info.Save()).ToArray();
+      ui.DefaultPlayProtocols["FLV"] = FLVPlayProtocol;
       wpf.BroadcastHistory = new BroadcastInfo[0];
       PeerCastStation.Core.PeerCastApplication.Current.SaveSettings();
     }


### PR DESCRIPTION
GUIやHTML UIから視聴URLを開く時に、コンテントタイプに合わせて既定のプロトコルを選択しプレイリストを生成できるようにした。
とりあえず今のところ指定して意味があるのがFLVだけなので、設定はFLVのみ行えるようになっている。