### PR TITLE
アセンブリ参照の大文字小文字を正常化。

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/PeerCastStation.Core.csproj
+++ b/PeerCastStation/PeerCastStation.Core/PeerCastStation.Core.csproj
@@ -43,10 +43,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.XML" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AccessController.cs" />

--- a/PeerCastStation/PeerCastStation.CustomFilter/PeerCastStation.CustomFilter.csproj
+++ b/PeerCastStation/PeerCastStation.CustomFilter/PeerCastStation.CustomFilter.csproj
@@ -38,8 +38,8 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CustomFilter.cs" />

--- a/PeerCastStation/PeerCastStation.HTTP/PeerCastStation.HTTP.csproj
+++ b/PeerCastStation/PeerCastStation.HTTP/PeerCastStation.HTTP.csproj
@@ -46,8 +46,8 @@
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
-    <Reference Include="System.XML" />
     <Reference Include="WindowsBase" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="HTTPChunkedContentStream.cs" />

--- a/PeerCastStation/PeerCastStation.UI.HTTP/PeerCastStation.UI.HTTP.csproj
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/PeerCastStation.UI.HTTP.csproj
@@ -48,8 +48,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AdminHost.cs" />

--- a/PeerCastStation/PeerCastStation/PeerCastStation.csproj
+++ b/PeerCastStation/PeerCastStation/PeerCastStation.csproj
@@ -58,8 +58,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Configuration" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="PeerCastStation.cs" />


### PR DESCRIPTION
アセンブリ名を構成する単語が先頭大文字になっていなくて、DLLのファイル名と異なるために
Monoでビルドできなかったので先頭大文字にしました。

追記：
参考URL [Ubuntuで​新安定版​ペカステ(2.6.0)を​ビルドする​方法](http://ie.pcgw.pgw.jp/2019/02/25/building-pecast260-on-ubuntu.html)