### PR TITLE
HTML UIで既存のYP項目を編集できるようにした

### DIFF
--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/js/settings.js
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/js/settings.js
@@ -400,6 +400,48 @@ var SettingsViewModel = new function() {
     });
   }
 
+  self.editYellowPage = function() {
+    var checkedItems = self.yellowPages().filter(function (yp) { return yp.checked(); });
+
+    if (checkedItems.length == 0) {
+      alert("編集するYPを1つ選択してください。");
+      return;
+    }
+    if (checkedItems.length > 1) {
+      alert("選択するYPは1つにしてください。");
+      return;
+    }
+
+    var target = checkedItems[0];
+    YellowPageEditDialog.name(target.name());
+    YellowPageEditDialog.announceUri(target.announceUri());
+    YellowPageEditDialog.channelsUri(target.channelsUri());
+    YellowPageEditDialog.protocol(target.protocol());
+
+    YellowPageEditDialog.show(function(yp) {
+      var announce_uri = yp.announceUri();
+      if (announce_uri==null || announce_uri==="") {
+        announce_uri = null;
+      }
+      else if (!announce_uri.match(/^\w+:\/\//)) {
+        announce_uri = yp.protocol() + '://' + yp.announceUri();
+      }
+      var channels_uri = yp.channelsUri();
+      if (channels_uri==null || channels_uri==="") {
+        channels_uri = null;
+      }
+      PeerCast.addYellowPage(yp.protocol(), yp.name(), announce_uri, channels_uri, function(res, err) {
+        if (err) {
+          alert("YPの追加に失敗しました: " + err.message);
+          return;
+        }
+        PeerCast.removeYellowPage(target.id(), function() {
+          self.update();
+        });
+      });
+    });
+  }
+
   self.addListener = function() {
     ListenerEditDialog.show(function(listener) {
       PeerCast.addListener(

--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/js/settings.js
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/js/settings.js
@@ -383,7 +383,11 @@ var SettingsViewModel = new function() {
       if (channels_uri==null || channels_uri==="") {
         channels_uri = null;
       }
-      PeerCast.addYellowPage(yp.protocol(), yp.name(), announce_uri, channels_uri, function() {
+      PeerCast.addYellowPage(yp.protocol(), yp.name(), announce_uri, channels_uri, function(res, err) {
+        if (err) {
+          alert("YPの追加に失敗しました: " + err.message);
+          return;
+        }
         self.update();
       });
     });

--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/js/settings.js
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/js/settings.js
@@ -66,6 +66,13 @@ var YellowPageEditDialog = new function() {
     self.onOK(self);
     dialog.modal('hide');
   };
+
+  self.clear = function() {
+    self.name("");
+    self.protocol("");
+    self.announceUri("");
+    self.channelsUri("");
+  };
 };
 
 var ListenerEditDialog = new function() {
@@ -363,6 +370,7 @@ var SettingsViewModel = new function() {
   };
 
   self.addYellowPage = function() {
+    YellowPageEditDialog.clear();
     YellowPageEditDialog.show(function(yp) {
       var announce_uri = yp.announceUri();
       if (announce_uri==null || announce_uri==="") {

--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/js/settings.js
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/js/settings.js
@@ -371,7 +371,7 @@ var SettingsViewModel = new function() {
 
   self.addYellowPage = function() {
     YellowPageEditDialog.clear();
-    YellowPageEditDialog.show(function(yp) {
+    YellowPageEditDialog.show(function onOK(yp) {
       var announce_uri = yp.announceUri();
       if (announce_uri==null || announce_uri==="") {
         announce_uri = null;
@@ -386,6 +386,7 @@ var SettingsViewModel = new function() {
       PeerCast.addYellowPage(yp.protocol(), yp.name(), announce_uri, channels_uri, function(res, err) {
         if (err) {
           alert("YPの追加に失敗しました: " + err.message);
+          YellowPageEditDialog.show(onOK);
           return;
         }
         self.update();
@@ -418,7 +419,7 @@ var SettingsViewModel = new function() {
     YellowPageEditDialog.channelsUri(target.channelsUri());
     YellowPageEditDialog.protocol(target.protocol());
 
-    YellowPageEditDialog.show(function(yp) {
+    YellowPageEditDialog.show(function onOK(yp) {
       var announce_uri = yp.announceUri();
       if (announce_uri==null || announce_uri==="") {
         announce_uri = null;
@@ -433,6 +434,7 @@ var SettingsViewModel = new function() {
       PeerCast.addYellowPage(yp.protocol(), yp.name(), announce_uri, channels_uri, function(res, err) {
         if (err) {
           alert("YPの追加に失敗しました: " + err.message);
+          YellowPageEditDialog.show(onOK);
           return;
         }
         PeerCast.removeYellowPage(target.id(), function() {

--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/settings.html
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/settings.html
@@ -204,7 +204,7 @@
           <table class="table table-condensed">
             <thead>
               <tr>
-                <th>削除</th>
+                <th>選択</th>
                 <th>YP名</th>
                 <th>プロトコル</th>
                 <th>配信掲載URL</th>
@@ -216,6 +216,7 @@
                 <td class="form-actions" colspan="5">
                   <button class="btn" data-bind="click:addYellowPage">追加</button>
                   <button class="btn" data-bind="click:removeYellowPages">削除</button>
+                  <button class="btn" data-bind="click:editYellowPage">編集</button>
                 </td>
               </tr>
             </tfoot>
@@ -267,7 +268,7 @@
     <div id="yellowPageEditDialog" class="modal" style="display: none; max-height: inherit">
       <div class="modal-header">
         <a class="close" data-dismiss="modal">×</a>
-        <h3>YP追加</h3>
+        <h3>YP編集</h3>
       </div>
       <div class="modal-body">
         <div class="form-horizontal">
@@ -299,7 +300,7 @@
       </div>
       <div class="modal-footer">
         <a data-dismiss="modal" class="btn">閉じる</a>
-        <a href="#" data-bind="click:onUpdate" class="btn btn-primary">追加</a>
+        <a href="#" data-bind="click:onUpdate" class="btn btn-primary">保存</a>
       </div>
     </div>
 


### PR DESCRIPTION
HTML UIでは、既存のYP項目の内容を修正したい時に、削除・追加を行う必要があったので、既存の項目をダイアログで開いて保存できるようにしました。

* 追加用のダイアログと共用にしたので、ダイアログの文言を若干修正しました。
* URLから`http://`が抜けているなどの理由でYPが追加できなかった場合に、アラートウィンドウを表示して、ダイアログにもどるようにしました。