### PR TITLE
「認証情報の表示」ボタンにスタイルを付けた。

### DIFF
--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/settings.html
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/settings.html
@@ -113,7 +113,7 @@
                     パスワード: <span data-bind="text:authenticationPassword"></span>
                   </div>
                   <div data-bind="ifnot: authenticationInfoVisibility">
-                    <button data-bind="click:showAuthenticationInfo">認証情報の表示</button> 
+                    <button class="btn" data-bind="click:showAuthenticationInfo">認証情報の表示</button> 
                   </div>
                 </td>
               </tr>


### PR DESCRIPTION
HTML UIの「設定」ページで「認証情報の表示」ボタンにBootstrapのスタイルが付いていなかったのでbtnクラスを付けました。

前(Windows 7):
![image](https://user-images.githubusercontent.com/1680210/53508162-8dff5000-3afc-11e9-83a9-c26806dd59bd.png)

後:
![image](https://user-images.githubusercontent.com/1680210/53508165-90fa4080-3afc-11e9-8eb1-1c68e3d22fc0.png)
