### PR TITLE
HTML UIログページのクリアボタンをfloatで右に寄せるようにした

### DIFF
--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/logs.html
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/logs.html
@@ -61,7 +61,7 @@
             <option value="4">情報</option>
             <option value="5">デバッグ</option>
           </select>
-          <button style="float: right" class="btn" data-bind="click:clear"><i class="icon-trash"></i>クリア</button>
+          <button class="btn pull-right" data-bind="click:clear"><i class="icon-trash"></i>クリア</button>
         </div>
       </div>
       <div class="row-fluid">

--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/logs.html
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/logs.html
@@ -53,7 +53,7 @@
     <div class="container-fluid" id="logs">
       <h1>ログ</h1>
       <div class="row-fluid">
-        <div class="span11">
+        <div class="span12">
           <select data-bind="value:logLevel">
             <option value="0">なし</option>
             <option value="2">エラー</option>
@@ -61,9 +61,7 @@
             <option value="4">情報</option>
             <option value="5">デバッグ</option>
           </select>
-        </div>
-        <div class="span1">
-          <button class="btn" data-bind="click:clear">クリア</button>
+          <button style="float: right" class="btn" data-bind="click:clear"><i class="icon-trash"></i>クリア</button>
         </div>
       </div>
       <div class="row-fluid">


### PR DESCRIPTION
ウィンドウ幅が狭いときに「クリア」ボタンの文字が折り返されがちだったので、グリッドシステムを使わずに右に寄せるようにしました。

ついでにアイコンも付けてみました。

![image](https://user-images.githubusercontent.com/1680210/53510298-fe0fd500-3b00-11e9-8aa4-629f4c94035e.png)
