### PR TITLE
[HTML UI] 配信開始操作の失敗時にエラーメッセージ

### DIFF
--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/js/relays.js
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/js/relays.js
@@ -363,7 +363,10 @@ var BroadcastDialog = new function() {
         contentReader,
         info,
         track,
-        function() {
+        function(res, err) {
+          if (err) {
+            alert("エラー: " + err.message);
+          }
           refresh();
           dialog.modal('hide');
         });


### PR DESCRIPTION
配信開始ボタンを押してもチャンネルが立たなかった時にエラーメッセージが表示されるようにしました。

![image](https://user-images.githubusercontent.com/1680210/53683581-ce054380-3d45-11e9-8a96-0d8e63c44227.png)
