### PR TITLE
[GUI] 接続待ち受けタブから設定できるポート番号の下限値を1に下げた。

### DIFF
--- a/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingControl.xaml
+++ b/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingControl.xaml
@@ -254,7 +254,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. -->
                     <ComboBoxItem Content="IPv6 Any"/>
                   </ComboBox>
                   <Label Grid.Row="0" Grid.Column="2" Content="ポート:"/>
-                  <peca:IntegerUpDown    Grid.Row="0" Grid.Column="3" Minimum="1024" Maximum="65535" Value="{Binding Port}"/>
+                  <peca:IntegerUpDown    Grid.Row="0" Grid.Column="3" Minimum="1" Maximum="65535" Value="{Binding Port}"/>
                   <l:RelaySettingControl Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="4"/>
                   <Label Grid.Column="0" Grid.Row="2" Content="ポート開放状態:"/>
                   <TextBlock Grid.Column="1" Grid.Row="2" Grid.ColumnSpan="3" VerticalAlignment="Center" Style="{StaticResource PortIsOpenText}"/>


### PR DESCRIPTION
全般タブでは 1024 未満の well-known なポートが指定できるのですが、接続待ち受けでは設定できません。

1024 未満のポート番号を使うのは勧められませんが、ISPにブロックされにくい80番ポートを設定できるのは、有用な可能性があり、また全般タブとの一貫性の観点から、下限を1に下げました。