### PR TITLE
ポートを新しく追加する時に常に1つだけ追加されるようにした。

### DIFF
--- a/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingViewModel.cs
+++ b/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingViewModel.cs
@@ -739,7 +739,7 @@ namespace PeerCastStation.WPF.CoreSettings
     {
       this.pecaApp = peca_app;
       this.peerCast = peca_app.PeerCast;
-      this.AddPortCommand = new Command(() => AddPort(PrimaryPort, NetworkType.IPv4));
+      this.AddPortCommand = new Command(() => AddPort(7144, NetworkType.IPv4));
       this.RemovePortCommand = new Command(() => RemovePort(), () => SelectedPort!=null);
       this.AddYellowPageCommand = new Command(() => AddYellowPage());
       this.RemoveYellowPageCommand = new Command(() => RemoveYellowPage(), () => SelectedYellowPage!=null);


### PR DESCRIPTION
イシュー #397 の修正案です。

ポートが1つも無い状態だとPrimaryPortプロパティの取得時に7144ポートが追加されるので、PrimaryPortを参照しないようにしました。