### PR TITLE
IPv6ポートの認証付きURLが不正になるのを修正。

### DIFF
--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/js/settings.js
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/js/settings.js
@@ -160,10 +160,14 @@ var ListenerViewModel = function(value) {
   self.authenticationInfoVisibility = ko.observable(false);
   self.authUrl = ko.computed(function () {
     var addr = self.address();
-    if (addr=='0.0.0.0' || addr=='0::0') {
-      addr = window.location.hostname;
+    var ipv6 = !!addr.match(/\:/);
+    if (addr=='0.0.0.0' || addr=='0::0' || addr=='::') {
+      return "http://" + window.location.hostname + ":" + self.port() + "/?auth=" + self.authToken();
+    } else if (ipv6) {
+      return "http://[" + addr + "]:" + self.port() + "/?auth=" + self.authToken();
+    } else {
+      return "http://" + addr + ":" + self.port() + "/?auth=" + self.authToken();
     }
-    return "http://" + addr + ":" + self.port() + "/?auth=" + self.authToken();
   });
   self.portStatus = ko.computed(function() {
     switch (self.isOpened()) {


### PR DESCRIPTION
#402 の修正案です。

IPv6待ち受けアドレスは正しく角括弧に囲まれるようにしました。
ただし待ち受けアドレスが `::` の場合も`0.0.0.0`や`0::0`の場合と同じく Any アドレスとして扱って、`window.location.hostname` の値を使うようにしました。
したがって、IPv4でHTML UI を開いている場合は正しいURLになりませんが、リモートからIPv6アドレスでUIを開いている場合は正しくなるはずです。