### PR TITLE
Ringbuffer.CopyToでコピー先の配列が必要以上に長い時例外が上がるのを修正

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/Ringbuffer.cs
+++ b/PeerCastStation/PeerCastStation.Core/Ringbuffer.cs
@@ -44,7 +44,7 @@ namespace PeerCastStation.Core
     {
       if (array==null) throw new ArgumentNullException("array");
       if (arrayIndex<0) throw new ArgumentOutOfRangeException("arrayIndex");
-      if (array.Length-arrayIndex>count) throw new ArgumentException();
+      if (array.Length-arrayIndex<count) throw new ArgumentException("array not long enough");
       var firsthalf = Math.Min(Capacity-top, count);
       Array.Copy(buffer, top, array, arrayIndex, firsthalf);
       if (firsthalf<count) {


### PR DESCRIPTION
Ringbuffer.CopyToでコピー先の配列が必要以上に長い時に、ArgumentException 例外が上がります。

```
      var b = new Ringbuffer<string>(1000);
      b.Add("a");
      b.Add("b");
      b.Add("c");
      var arr = new string[4]; // string[3] で十分。
      b.CopyTo(arr, 0); // ArgumentException 例外。
```

Mono では Ringbuffer を IEnumerable.Concat で別のシーケンスと連結した後 ToArray すると、Ringbuffer 以上の長さの配列に対して Ringbuffer の内容を CopyTo しようとします。

```
      var b = new Ringbuffer<string>(1000);
      b.Add("a");
      b.Add("b");
      b.Add("c");
      var c = b.Concat(Enumerable.Repeat("d", 1));
      c.ToArray(); // ArgumentException 例外。
```

ペカステの実際の挙動でこの問題に遭遇することはないのですが、仮に Mono で LogWriter.ToString が呼ばれたとしたら失敗します。

Ringbuffer.CopyTo冒頭のガードで、リングバッファーの要素数を超える長さのコピー先配列が渡された場合に例外が上がるようになっているのですが、配列に必要な長さがあることをチェックするのが意図のように思いましたので、そのように変えました。