### PR TITLE
GUIの全般タブで1024未満のポート番号を設定できるようになっていたのを修正した

### DIFF
--- a/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingControl.xaml
+++ b/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingControl.xaml
@@ -126,7 +126,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. -->
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="Auto"/>
                   </Grid.ColumnDefinitions>
-                  <peca:IntegerUpDown Minimum="1" Maximum="65535" Increment="1" Value="{Binding PrimaryPort}"/>
+                  <peca:IntegerUpDown Minimum="1024" Maximum="65535" Increment="1" Value="{Binding PrimaryPort}"/>
                   <CheckBox Grid.Column="1" Margin="2" VerticalAlignment="Center" Content="IPv6も使う" IsChecked="{Binding IPv6Enabled}"/>
                 </Grid>
                 <Label     Grid.Column="0" Grid.Row="1" Content="ポート自動開放:"/>


### PR DESCRIPTION
詳細の接続設定では1024未満のポート番号が設定できなかったのに、全般タブで1024未満のポート番号を設定できるようになっていたので設定できない方に合わせた。(するべきではない)