### PR TITLE
GUIで接続待ち受けアドレス入力の検証を行うようにした

### DIFF
--- a/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingControl.xaml
+++ b/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingControl.xaml
@@ -249,7 +249,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. -->
                     <RowDefinition Height="Auto"/>
                   </Grid.RowDefinitions>
                   <Label    Grid.Row="0" Grid.Column="0" Content="アドレス:"/>
-                  <ComboBox Grid.Row="0" Grid.Column="1" IsEditable="True" Text="{Binding Address}">
+                  <ComboBox Grid.Row="0" Grid.Column="1" IsEditable="True">
+                    <ComboBox.Text>
+                      <Binding Path="Address">
+                        <Binding.ValidationRules>
+                          <l:BindableAddressValidationRule />
+                        </Binding.ValidationRules>
+                      </Binding>
+                    </ComboBox.Text>
                     <ComboBoxItem Content="IPv4 Any"/>
                     <ComboBoxItem Content="IPv6 Any"/>
                   </ComboBox>

--- a/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingControl.xaml
+++ b/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingControl.xaml
@@ -25,6 +25,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. -->
   <Grid>
     <Grid.Resources>
       <BooleanToVisibilityConverter x:Key="visibilityConverter"/>
+      <Style TargetType="ComboBox">
+        <Style.Triggers>
+          <Trigger Property="Validation.HasError" Value="true">
+            <Setter Property="ToolTip" Value="{Binding RelativeSource={RelativeSource Self}, Path=(Validation.Errors)[0].ErrorContent}"/>
+          </Trigger>
+        </Style.Triggers>
+      </Style>
       <Style TargetType="TextBox">
         <Style.Triggers>
           <Trigger Property="Validation.HasError" Value="true">
@@ -251,7 +258,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. -->
                   <Label    Grid.Row="0" Grid.Column="0" Content="アドレス:"/>
                   <ComboBox Grid.Row="0" Grid.Column="1" IsEditable="True">
                     <ComboBox.Text>
-                      <Binding Path="Address">
+                      <Binding Path="Address" NotifyOnValidationError="True">
                         <Binding.ValidationRules>
                           <l:BindableAddressValidationRule />
                         </Binding.ValidationRules>

--- a/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingControl.xaml.cs
+++ b/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingControl.xaml.cs
@@ -13,6 +13,7 @@
 // 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
+using System;
 using System.Linq;
 using System.Globalization;
 using System.Windows;
@@ -63,7 +64,7 @@ namespace PeerCastStation.WPF.CoreSettings
     public override ValidationResult Validate(object value, CultureInfo cultureInfo)
     {
       var str = value as string;
-      if (str==null) return new ValidationResult(false, "Invalid Address");
+      if (String.IsNullOrWhiteSpace(str)) return new ValidationResult(false, "アドレスを入力してください");
       switch (str) {
       case "IPv4 Any":
       case "IPv6 Any":
@@ -88,12 +89,12 @@ namespace PeerCastStation.WPF.CoreSettings
               return new ValidationResult(true, null);
             }
             else {
-              return new ValidationResult(false, "Invalid Address");
+              return new ValidationResult(false, "接続待ち受けに使用できないアドレスです");
             }
           }
         }
         else {
-          return new ValidationResult(false, "Invalid Address");
+          return new ValidationResult(false, "アドレスの形式が正しくありません");
         }
       }
     }

--- a/PeerCastStation/PeerCastStation.WPF/SettingsDialog.xaml
+++ b/PeerCastStation/PeerCastStation.WPF/SettingsDialog.xaml
@@ -8,6 +8,7 @@
         Height="480"
         ResizeMode="CanResizeWithGrip"
         WindowStartupLocation="CenterOwner"
+        Validation.Error="Window_Error"
         Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}">
   <Grid Margin="4">
     <Grid.RowDefinitions>
@@ -16,9 +17,9 @@
     </Grid.RowDefinitions>
     <settings:SettingControl Grid.Row="0"/>
     <UniformGrid Grid.Row="1" HorizontalAlignment="Right" Rows="1" Columns="3">
-      <Button Margin="4" Padding="4" Content="OK" Click="OKButton_Click"/>
-      <Button Margin="4" Padding="4" Content="キャンセル" Click="CancelButton_Click"/>
-      <Button Margin="4" Padding="4" Content="適用" IsEnabled="{Binding IsModified}" Click="ApplyButton_Click"/>
+      <Button Margin="4" Padding="4" Content="OK" Command="{Binding RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=Window}, Path=OKCommand}"/>
+      <Button Margin="4" Padding="4" Content="キャンセル" Command="{Binding RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=Window}, Path=CancelCommand}"/>
+      <Button Margin="4" Padding="4" Content="適用" Command="{Binding RelativeSource={RelativeSource Mode=FindAncestor,AncestorType=Window}, Path=ApplyCommand}"/>
     </UniformGrid>
   </Grid>
 </Window>


### PR DESCRIPTION
GUIで接続待ち受けアドレスに正しくない値を入力すると適用時に落ちていたので、
アドレスの値を検証して使えないアドレスの場合はOKや適用ボタンを押せないようにした。