### PR TITLE
起動時のポートチェックをUPnPでのポート開放後に行うようにした

### DIFF
--- a/PeerCastStation/PeerCastStation.UI/PCPPortChecker.cs
+++ b/PeerCastStation/PeerCastStation.UI/PCPPortChecker.cs
@@ -36,19 +36,6 @@ namespace PeerCastStation.UI
         TargetUriV6 = target_uri;
       }
       base.OnStart();
-      CheckAsync()
-        .ContinueWith(prev => {
-          if (prev.IsCanceled || prev.IsFaulted) return;
-          foreach (var result in prev.Result) {
-            if (!result.Success) continue;
-            if (result.IsOpen) {
-              this.Application.PeerCast.SetPortStatus(result.LocalAddress, result.GlobalAddress, PortStatus.Open);
-            }
-            else {
-              this.Application.PeerCast.SetPortStatus(result.LocalAddress, result.GlobalAddress, PortStatus.Firewalled);
-            }
-          }
-        });
     }
 
     public async Task<PortCheckResult[]> CheckAsync()


### PR DESCRIPTION
起動時のポートチェックはUPnPでのポート開放とは独立に行っていたが、ポート開放される前にポートチェックが行われて未開放になってしまっていたので、UPnPのポート開放後にポートチェックを実行するようにした。