### PR TITLE
チャンネルのコンテントパケットに非キーフレームフラグを持たせるようにした

### DIFF
--- a/PeerCastStation/PeerCastStation.ASF/ASFContentReader.cs
+++ b/PeerCastStation/PeerCastStation.ASF/ASFContentReader.cs
@@ -524,7 +524,7 @@ namespace PeerCastStation.ASF
             streamOrigin = DateTime.Now;
             contentPosition = 0;
             var data = chunk.ToByteArray();
-            sink.OnContentHeader(new Content(streamIndex, TimeSpan.Zero, contentPosition, data));
+            sink.OnContentHeader(new Content(streamIndex, TimeSpan.Zero, contentPosition, data, PCPChanPacketContinuation.None));
             contentPosition += data.Length;
             break;
           }
@@ -532,7 +532,7 @@ namespace PeerCastStation.ASF
           {
             var data = chunk.ToByteArray();
             sink.OnContent(
-              new Content(streamIndex, DateTime.Now-streamOrigin, contentPosition, chunk.ToByteArray())
+              new Content(streamIndex, DateTime.Now-streamOrigin, contentPosition, chunk.ToByteArray(), PCPChanPacketContinuation.None)
             );
             contentPosition += data.Length;
           }

--- a/PeerCastStation/PeerCastStation.Core/Atom.cs
+++ b/PeerCastStation/PeerCastStation.Core/Atom.cs
@@ -157,6 +157,30 @@ namespace PeerCastStation.Core
   }
 
   /// <summary>
+  /// PCP_CHAN_PKT_CONTINUATIONに設定する値です
+  /// </summary>
+  [Flags]
+  public enum PCPChanPacketContinuation : byte
+  {
+    /// <summary>
+    /// 指定無し
+    /// </summary>
+    None          = 0x00,
+    /// <summary>
+    /// 分割されたパケットである
+    /// </summary>
+    Fragment      = 0x01,
+    /// <summary>
+    /// 中間フレームである
+    /// </summary>
+    IntraFrame    = 0x02,
+    /// <summary>
+    /// 音声パケットである
+    /// </summary>
+    AudioFrame    = 0x04,
+  }
+
+  /// <summary>
   /// PCPプロトコルの基本通信単位を表すクラスです。
   /// 4文字以下の名前と対応する値を保持します
   /// </summary>
@@ -186,6 +210,7 @@ namespace PeerCastStation.Core
     public static readonly ID4 PCP_CHAN_PKT_META          = new ID4("meta");
     public static readonly ID4 PCP_CHAN_PKT_POS           = new ID4("pos");
     public static readonly ID4 PCP_CHAN_PKT_DATA          = new ID4("data");
+    public static readonly ID4 PCP_CHAN_PKT_CONTINUATION  = new ID4("cont");
     public static readonly ID4 PCP_CHAN_PKT_TYPE_HEAD     = new ID4("head");
     public static readonly ID4 PCP_CHAN_PKT_TYPE_META     = new ID4("meta");
     public static readonly ID4 PCP_CHAN_PKT_TYPE_DATA     = new ID4("data");

--- a/PeerCastStation/PeerCastStation.Core/AtomCollectionExtensions.cs
+++ b/PeerCastStation/PeerCastStation.Core/AtomCollectionExtensions.cs
@@ -307,6 +307,11 @@ namespace PeerCastStation.Core
       return GetUIntFrom(collection, Atom.PCP_CHAN_PKT_POS);
     }
 
+    public static PCPChanPacketContinuation GetChanPktCont(this IAtomCollection collection)
+    {
+      return (PCPChanPacketContinuation)(GetByteFrom(collection, Atom.PCP_CHAN_PKT_CONTINUATION) ?? 0);
+    }
+
     public static byte[] GetChanPktData(this IAtomCollection collection)
     {
       return GetBytesFrom(collection, Atom.PCP_CHAN_PKT_DATA);
@@ -785,6 +790,11 @@ namespace PeerCastStation.Core
     public static void SetChanPktData(this IAtomCollection collection, byte[] value)
     {
       SetAtomTo(collection, new Atom(Atom.PCP_CHAN_PKT_DATA, value));
+    }
+
+    public static void SetChanPktCont(this IAtomCollection collection, PCPChanPacketContinuation value)
+    {
+      SetAtomTo(collection, new Atom(Atom.PCP_CHAN_PKT_CONTINUATION, (byte)value));
     }
 
     public static void SetChanPktPos(this IAtomCollection collection, uint value)

--- a/PeerCastStation/PeerCastStation.Core/Channel.cs
+++ b/PeerCastStation/PeerCastStation.Core/Channel.cs
@@ -380,7 +380,7 @@ namespace PeerCastStation.Core
           sink.OnChannelTrack(channel_track);
         }
         sink.OnContentHeader(header);
-        var contents = Contents.GetNewerContents(header.Stream, header.Timestamp, header.Position);
+        var contents = Contents.GetFirstContents(header.Stream, header.Timestamp, header.Position);
         foreach (var content in contents) {
           if (header.Position>=requestPos || content.Position>=requestPos) {
             sink.OnContent(content);
@@ -429,26 +429,6 @@ namespace PeerCastStation.Core
       DispatchSinkEvent(sink => {
         sink.OnContentHeader(header);
       });
-    }
-
-    private void OnContentChanged()
-    {
-      var header = contentHeader;
-      if (header!=null) {
-        OnContentHeaderChanged(header);
-        var channel_info = ChannelInfo;
-        if (channel_info!=null) {
-          OnChannelInfoChanged(channel_info);
-        }
-        var channel_track = ChannelTrack;
-        if (channel_track!=null) {
-          OnChannelTrackChanged(channel_track);
-        }
-        var contents = Contents.GetNewerContents(header.Stream, header.Timestamp, header.Position);
-        foreach (var content in contents) {
-          OnContentAdded(content);
-        }
-      }
     }
 
     internal void OnContentAdded(Content content)

--- a/PeerCastStation/PeerCastStation.Core/ContentSink.cs
+++ b/PeerCastStation/PeerCastStation.Core/ContentSink.cs
@@ -36,6 +36,7 @@ namespace PeerCastStation.Core
       private bool empty = true;
       private int stream;
       private long position;
+      private PCPChanPacketContinuation contFlag;
       private TimeSpan timestamp;
       private TimeSpan lastTimestamp;
       private MemoryStream dataBuffer = new MemoryStream(16*1024);
@@ -48,6 +49,7 @@ namespace PeerCastStation.Core
         if (empty) {
           stream = content.Stream;
           position = content.Position;
+          contFlag = content.ContFlag;
           timestamp = content.Timestamp;
           lastTimestamp = timestamp;
           dataBuffer.SetLength(0);
@@ -56,9 +58,10 @@ namespace PeerCastStation.Core
           return true;
         }
         else if (stream!=content.Stream ||
+                 contFlag!=content.ContFlag ||
                  position+dataBuffer.Length!=content.Position ||
                  Math.Abs((content.Timestamp-lastTimestamp).TotalMilliseconds)>100.0 ||
-                 dataBuffer.Length+content.Data.Length>15*1024) {
+                 dataBuffer.Length+content.Data.Length>8*1024) {
           return false;
         }
         else {
@@ -72,7 +75,7 @@ namespace PeerCastStation.Core
       {
         if (empty) return null;
         dataBuffer.Flush();
-        return new Content(stream, timestamp, position, dataBuffer.ToArray());
+        return new Content(stream, timestamp, position, dataBuffer.ToArray(), contFlag);
       }
 
       public void Clear()

--- a/PeerCastStation/PeerCastStation.Core/RawContentReader.cs
+++ b/PeerCastStation/PeerCastStation.Core/RawContentReader.cs
@@ -22,7 +22,7 @@ namespace PeerCastStation.Core
       long pos = 0;
       var streamIndex = Channel.GenerateStreamID();
       var streamOrigin = DateTime.Now;
-      sink.OnContentHeader(new Content(streamIndex, TimeSpan.Zero, pos, new byte[] { }));
+      sink.OnContentHeader(new Content(streamIndex, TimeSpan.Zero, pos, new byte[] { }, PCPChanPacketContinuation.None));
       var channel_info = new AtomCollection(Channel.ChannelInfo.Extra);
       channel_info.SetChanInfoType("RAW");
       channel_info.SetChanInfoStreamType("application/octet-stream");
@@ -34,7 +34,7 @@ namespace PeerCastStation.Core
         var buf = new byte[8192];
         var sz = await stream.ReadAsync(buf, 0, buf.Length, cancel_token).ConfigureAwait(false);
         if (sz>0) {
-          sink.OnContent(new Content(streamIndex, DateTime.Now-streamOrigin, pos, buf.Take(sz).ToArray()));
+          sink.OnContent(new Content(streamIndex, DateTime.Now-streamOrigin, pos, buf.Take(sz).ToArray(), PCPChanPacketContinuation.None));
           pos += sz;
         }
         else {

--- a/PeerCastStation/PeerCastStation.CustomFilter/CustomFilter.cs
+++ b/PeerCastStation/PeerCastStation.CustomFilter/CustomFilter.cs
@@ -180,7 +180,7 @@ namespace PeerCastStation.CustomFilter
             var len = await stdout.ReadAsync(buffer, 0, buffer.Length, cancel).ConfigureAwait(false);
             System.Console.WriteLine("stdout {0}", len);
             if (len<=0) break;
-            Sink.OnContent(new Content(lastContent.Stream, lastContent.Timestamp, pos, buffer, 0, len));
+            Sink.OnContent(new Content(lastContent.Stream, lastContent.Timestamp, pos, buffer, 0, len, PCPChanPacketContinuation.None));
             pos += len;
           }
           stdout.Close();
@@ -235,7 +235,7 @@ namespace PeerCastStation.CustomFilter
 
     public void OnContentHeader(Content content_header)
     {
-      Sink.OnContentHeader(new Content(content_header.Stream, content_header.Timestamp, 0, new byte[0]));
+      Sink.OnContentHeader(new Content(content_header.Stream, content_header.Timestamp, 0, new byte[0], PCPChanPacketContinuation.None));
       OnContent(content_header);
     }
 

--- a/PeerCastStation/PeerCastStation.FLV/FLVToMPEG2TS.cs
+++ b/PeerCastStation/PeerCastStation.FLV/FLVToMPEG2TS.cs
@@ -11,6 +11,8 @@ namespace PeerCastStation.FLV
 {
   internal enum FLVPacketType {
     Unknown,
+    AudioData,
+    VideoData,
     AACSequenceHeader,
     AACRawData,
     AVCSequenceHeader,
@@ -24,7 +26,7 @@ namespace PeerCastStation.FLV
     {
       switch (msg.MessageType) {
       case RTMPMessageType.Audio:
-        if (msg.Body.Length<2) return FLVPacketType.Unknown;
+        if (msg.Body.Length<2) return FLVPacketType.AudioData;
         switch ((msg.Body[0] & 0xF0)>>4) {
         case 10:
           if (msg.Body[1]==0) {
@@ -34,10 +36,10 @@ namespace PeerCastStation.FLV
             return FLVPacketType.AACRawData;
           }
         default:
-          return FLVPacketType.Unknown;
+          return FLVPacketType.AudioData;
         }
       case RTMPMessageType.Video:
-        if (msg.Body.Length<2) return FLVPacketType.Unknown;
+        if (msg.Body.Length<2) return FLVPacketType.VideoData;
         switch (msg.Body[0] & 0x0F) {
         case 7:
           switch (msg.Body[1]) {
@@ -54,10 +56,10 @@ namespace PeerCastStation.FLV
           case 2:
             return FLVPacketType.AVCEOS;
           default:
-            return FLVPacketType.Unknown;
+            return FLVPacketType.VideoData;
           }
         default:
-          return FLVPacketType.Unknown;
+          return FLVPacketType.VideoData;
         }
       default:
         return FLVPacketType.Unknown;
@@ -961,7 +963,8 @@ namespace PeerCastStation.FLV
                     msg.Content.Stream,
                     msg.Content.Timestamp,
                     msg.Content.Position,
-                    bufferStream.ToArray()
+                    bufferStream.ToArray(),
+                    msg.Content.ContFlag
                   )
                 );
                 bufferStream.SetLength(0);
@@ -991,7 +994,8 @@ namespace PeerCastStation.FLV
                     msg.Content.Stream,
                     msg.Content.Timestamp,
                     msg.Content.Position,
-                    bufferStream.ToArray()
+                    bufferStream.ToArray(),
+                    msg.Content.ContFlag
                   )
                 );
                 bufferStream.SetLength(0);

--- a/PeerCastStation/PeerCastStation.MKV/MKVContentReader.cs
+++ b/PeerCastStation/PeerCastStation.MKV/MKVContentReader.cs
@@ -359,7 +359,7 @@ namespace PeerCastStation.MKV
               stream_origin = DateTime.Now;
               position = 0;
               sink.OnContentHeader(
-                new Content(stream_index, TimeSpan.Zero, 0, header.ToArray())
+                new Content(stream_index, TimeSpan.Zero, 0, header.ToArray(), PCPChanPacketContinuation.None)
               );
               position += header.ToArray().LongLength;
               var info = new AtomCollection();
@@ -421,7 +421,7 @@ namespace PeerCastStation.MKV
               var cluster = new Cluster(elt);
               clusters.AddLast(cluster);
               sink.OnContent(
-                new Content(stream_index, DateTime.Now-stream_origin, position, elt.ToArray())
+                new Content(stream_index, DateTime.Now-stream_origin, position, elt.ToArray(), PCPChanPacketContinuation.None)
               );
               position += elt.ByteSize;
               state = ReaderState.Timecode;
@@ -430,7 +430,7 @@ namespace PeerCastStation.MKV
                      elt.ID.BinaryEquals(Elements.CRC32)) {
               await elt.ReadBodyAsync(stream, cancel_token).ConfigureAwait(false);
               sink.OnContent(
-                new Content(stream_index, DateTime.Now-stream_origin, position, elt.ToArray())
+                new Content(stream_index, DateTime.Now-stream_origin, position, elt.ToArray(), PCPChanPacketContinuation.None)
               );
               position += elt.ByteSize;
             }
@@ -466,7 +466,7 @@ namespace PeerCastStation.MKV
                 }
               }
               sink.OnContent(
-                new Content(stream_index, DateTime.Now-stream_origin, position, elt.ToArray())
+                new Content(stream_index, DateTime.Now-stream_origin, position, elt.ToArray(), PCPChanPacketContinuation.None)
               );
               position += elt.ByteSize;
               state = ReaderState.Block;
@@ -474,7 +474,7 @@ namespace PeerCastStation.MKV
             else {
               await elt.ReadBodyAsync(stream, cancel_token).ConfigureAwait(false);
               sink.OnContent(
-                new Content(stream_index, DateTime.Now-stream_origin, position, elt.ToArray())
+                new Content(stream_index, DateTime.Now-stream_origin, position, elt.ToArray(), PCPChanPacketContinuation.None)
               );
               position += elt.ByteSize;
             }
@@ -500,14 +500,14 @@ namespace PeerCastStation.MKV
               clusters.Last.Value.BlockSize += elt.Size.Value;
               clusters.Last.Value.BlockID    = elt.ID.Binary;
               sink.OnContent(
-                new Content(stream_index, DateTime.Now-stream_origin, position, elt.ToArray())
+                new Content(stream_index, DateTime.Now-stream_origin, position, elt.ToArray(), PCPChanPacketContinuation.None)
               );
               position += elt.ByteSize;
             }
             else if (clusters.Last.Value.BlockID==null) {
               await elt.ReadBodyAsync(stream, cancel_token).ConfigureAwait(false);
               sink.OnContent(
-                new Content(stream_index, DateTime.Now-stream_origin, position, elt.ToArray())
+                new Content(stream_index, DateTime.Now-stream_origin, position, elt.ToArray(), PCPChanPacketContinuation.None)
               );
               position += elt.ByteSize;
             }

--- a/PeerCastStation/PeerCastStation.PCP/PCPSourceStream.cs
+++ b/PeerCastStation/PeerCastStation.PCP/PCPSourceStream.cs
@@ -566,12 +566,13 @@ Stopped:
     {
       var pkt_type = atom.Children.GetChanPktType();
       var pkt_data = atom.Children.GetChanPktData();
+      var pkt_cont = atom.Children.GetChanPktCont();
       if (pkt_type!=null && pkt_data!=null) {
         if (pkt_type==Atom.PCP_CHAN_PKT_TYPE_HEAD) {
           long pkt_pos = atom.Children.GetChanPktPos() ?? 0;
           streamIndex = Channel.GenerateStreamID();
           streamOrigin = DateTime.Now;
-          var header = new Content(streamIndex, TimeSpan.Zero, pkt_pos, pkt_data);
+          var header = new Content(streamIndex, TimeSpan.Zero, pkt_pos, pkt_data, pkt_cont);
           var info   = ResetContentType(lastInfo, header);
           contentSink.OnContentHeader(header);
           contentSink.OnChannelInfo(info);
@@ -582,7 +583,7 @@ Stopped:
         else if (pkt_type==Atom.PCP_CHAN_PKT_TYPE_DATA) {
           if (atom.Children.GetChanPktPos()!=null) {
             long pkt_pos = atom.Children.GetChanPktPos().Value;
-            contentSink.OnContent(new Content(streamIndex, DateTime.Now-streamOrigin, pkt_pos, pkt_data));
+            contentSink.OnContent(new Content(streamIndex, DateTime.Now-streamOrigin, pkt_pos, pkt_data, pkt_cont));
             lastPosition = pkt_pos;
           }
         }

--- a/PeerCastStation/PeerCastStation.TS/TSContentReader.cs
+++ b/PeerCastStation/PeerCastStation.TS/TSContentReader.cs
@@ -57,7 +57,7 @@ namespace PeerCastStation.TS
 
       streamIndex = Channel.GenerateStreamID();
       streamOrigin = DateTime.Now;
-      sink.OnContentHeader(new Content(streamIndex, TimeSpan.Zero, contentPosition, new byte[] {}));
+      sink.OnContentHeader(new Content(streamIndex, TimeSpan.Zero, contentPosition, new byte[] {}, PCPChanPacketContinuation.None));
       
       try
       {
@@ -86,7 +86,7 @@ namespace PeerCastStation.TS
               {
                 streamIndex = Channel.GenerateStreamID();
                 contentPosition = 0;
-                sink.OnContentHeader(new Content(streamIndex, DateTime.Now - streamOrigin, contentPosition, newHead));
+                sink.OnContentHeader(new Content(streamIndex, DateTime.Now - streamOrigin, contentPosition, newHead, PCPChanPacketContinuation.None));
                 contentPosition += newHead.Length;
                 latestHead = newHead;
               }
@@ -108,7 +108,7 @@ namespace PeerCastStation.TS
             if ((DateTime.Now - latestContentTime).Milliseconds > 50) {
               TryParseContent(packet, out contentData);
               if(contentData!=null) {
-                sink.OnContent(new Content(streamIndex, DateTime.Now - streamOrigin, contentPosition, contentData));
+                sink.OnContent(new Content(streamIndex, DateTime.Now - streamOrigin, contentPosition, contentData, PCPChanPacketContinuation.None));
                 contentPosition += contentData.Length;
                 latestContentTime = DateTime.Now;
               }


### PR DESCRIPTION
チャンネルのコンテントパケットに非キーフレームフラグを持たせることで、キーフレームから再生できるようにした。
チャンネルにIContentSinkを追加した時点でバッファにキーフレームがあれば、それ以降のパケットから返すようにした。
今のところ上流から流れてきたパケットとRTMPソースでのみ正しく非キーフレームフラグが設定される。