### PR TITLE
Windows10でしか使えないAPIを例外トラップ無しに呼んでいたのを修正した

### DIFF
--- a/PeerCastStation/PeerCastStation.WPF/Screen.cs
+++ b/PeerCastStation/PeerCastStation.WPF/Screen.cs
@@ -78,7 +78,15 @@ namespace PeerCastStation.WPF
     public static int GetDpiForWindow(System.Windows.Interop.WindowInteropHelper hwnd)
     {
       if (hwnd.Handle!=null && hwnd.Handle!=IntPtr.Zero) {
-        return (int)User32.GetDpiForWindow(hwnd.Handle);
+        try {
+          return (int)User32.GetDpiForWindow(hwnd.Handle);
+        }
+        catch (DllNotFoundException) {
+          return 96;
+        }
+        catch (EntryPointNotFoundException) {
+          return 96;
+        }
       }
       else {
         throw new InvalidOperationException();


### PR DESCRIPTION
GetDpiForWindowがWindows10以降にしか無くてそれ以前のWindowsで起動できなくなっていたので修正した。
#430 を参照