### PR TITLE
FLV配信の視聴時にCORSを許可する

### DIFF
--- a/PeerCastStation/PeerCastStation.HTTP/HTTPOutputStream.cs
+++ b/PeerCastStation/PeerCastStation.HTTP/HTTPOutputStream.cs
@@ -332,7 +332,6 @@ namespace PeerCastStation.HTTP
             ctx.Response.Headers.Add("Cache-Control", new string [] { "no-cache" });
             ctx.Response.Headers.Add("Server", new string [] { "Rex/9.0.2980" });
             ctx.Response.Headers.Add("Pragma", new string [] { "no-cache", @"features=""broadcast,playlist""" });
-            ctx.Response.Headers.Add("Access-Control-Allow-Origin", new string[] { "*" });
             ctx.Response.ContentType = "application/x-mms-framed";
             ctx.Response.Headers.Add("Connection", new string[] { "close" });
           }
@@ -340,6 +339,7 @@ namespace PeerCastStation.HTTP
             ctx.Response.ContentType = channel.ChannelInfo.MIMEType;
             ctx.Response.Headers.Add("Transfer-Encoding", new string [] { "chunked" });
           }
+          ctx.Response.Headers.Add("Access-Control-Allow-Origin", new string[] { "*" });
 
           Content sent_header = null;
           Content sent_packet = null;


### PR DESCRIPTION
## 概要
HTTPでの視聴リクエストに ```Access-Control-Allow-Origin: *```をつけた

#428 (HTTPでの視聴時にCORSを許可するようにした) で、
WMV配信にのみCORS許可が設定されていたため、FLV配信も許可するように修正しました！

## 現状の問題
flv.jsを使ってブラウザ上でFLV配信を再生しようとすると、下記のjsエラーが発生します。
使っているPeerCastStationのバージョンは2.9.1です。

```
'http://shule.peca.live:8144/stream/xxxx.flv' from origin 'http://peca.live' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
```