### PR TITLE
表示されるチャンネルの合計リレー・視聴数がおかしかったのを修正した

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/Channel.cs
+++ b/PeerCastStation/PeerCastStation.Core/Channel.cs
@@ -123,22 +123,14 @@ namespace PeerCastStation.Core
     /// 保持している全てのノードと自分ノードのリレー合計を取得します
     /// </summary>
     public int TotalRelays {
-      get {
-        return sinks
-          .Select(x => x.GetConnectionInfo())
-          .Sum(x => (x.Type.HasFlag(ConnectionType.Relay) ? 1 : 0) + (x.LocalRelays ?? 0));
-      }
+      get { return LocalRelays + Nodes.Sum(n => n.RelayCount); }
     }
 
     /// <summary>
     /// 保持している全てのノードと自分ノードの視聴数合計を取得します
     /// </summary>
     public int TotalDirects {
-      get {
-        return sinks
-          .Select(x => x.GetConnectionInfo())
-          .Sum(x => (x.Type.HasFlag(ConnectionType.Direct) ? 1 : 0) + (x.LocalDirects ?? 0));
-      }
+      get { return LocalDirects + Nodes.Sum(n => n.DirectCount); }
     }
 
     /// <summary>

--- a/PeerCastStation/PeerCastStation.Test/CoreTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/CoreTests.fs
@@ -1,0 +1,101 @@
+﻿module CoreTests
+
+open Xunit
+open System
+open PeerCastStation.Core
+open TestCommon
+
+[<Fact>]
+let ``チャンネルのローカル視聴・リレー数が正しく取れる`` () =
+    use peca = new PeerCast()
+    let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid())
+    Assert.Equal(0, channel.LocalDirects)
+    Assert.Equal(0, channel.LocalRelays)
+    let directs =
+        seq { 1..4 }
+        |> Seq.map (fun i ->
+            {
+                new IChannelSink with
+                    member this.OnBroadcast(from, packet) = ()
+                    member this.OnStopped(reason) = ()
+                    member this.GetConnectionInfo() =
+                        let info = ConnectionInfoBuilder()
+                        info.Type <- ConnectionType.Direct
+                        info.LocalDirects <- Some 0 |> Option.toNullable
+                        info.Build()
+            }
+        )
+        |> Seq.map channel.AddOutputStream 
+        |> Seq.toArray
+    let relays =
+        seq { 1..5 }
+        |> Seq.map (fun i ->
+            {
+                new IChannelSink with
+                    member this.OnBroadcast(from, packet) = ()
+                    member this.OnStopped(reason) = ()
+                    member this.GetConnectionInfo() =
+                        let info = ConnectionInfoBuilder()
+                        info.Type <- ConnectionType.Relay
+                        info.LocalDirects <- Some i |> Option.toNullable
+                        info.LocalRelays <- Some (i*2) |> Option.toNullable
+                        info.Build()
+            }
+        )
+        |> Seq.map channel.AddOutputStream 
+        |> Seq.toArray
+    Assert.Equal(4, channel.LocalDirects)
+    Assert.Equal(5, channel.LocalRelays)
+
+[<Fact>]
+let ``チャンネルの合計視聴・リレー数が正しく取れる`` () =
+    use peca = new PeerCast()
+    let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid())
+    Assert.Equal(0, channel.TotalDirects)
+    Assert.Equal(0, channel.TotalRelays)
+    let directs =
+        seq { 1..4 }
+        |> Seq.map (fun i ->
+            {
+                new IChannelSink with
+                    member this.OnBroadcast(from, packet) = ()
+                    member this.OnStopped(reason) = ()
+                    member this.GetConnectionInfo() =
+                        let info = ConnectionInfoBuilder()
+                        info.Type <- ConnectionType.Direct
+                        info.LocalDirects <- Some 0 |> Option.toNullable
+                        info.Build()
+            }
+        )
+        |> Seq.map channel.AddOutputStream 
+        |> Seq.toArray
+    let relays =
+        seq { 1..5 }
+        |> Seq.map (fun i ->
+            {
+                new IChannelSink with
+                    member this.OnBroadcast(from, packet) = ()
+                    member this.OnStopped(reason) = ()
+                    member this.GetConnectionInfo() =
+                        let info = ConnectionInfoBuilder()
+                        info.Type <- ConnectionType.Relay
+                        info.LocalDirects <- Some i |> Option.toNullable
+                        info.LocalRelays <- Some (i*2) |> Option.toNullable
+                        info.Build()
+            }
+        )
+        |> Seq.map channel.AddOutputStream 
+        |> Seq.toArray
+    let buildHost directs relays =
+        let host = HostBuilder()
+        host.SessionID <- Guid.NewGuid()
+        host.DirectCount <- directs
+        host.RelayCount <- relays
+        host.ToHost()
+    seq { 5..8 }
+    |> Seq.map (fun i -> buildHost i (i*2))
+    |> Seq.iter channel.AddNode
+    Assert.Equal(4+5+6+7+8, channel.TotalDirects)
+    Assert.Equal(5+(5+6+7+8)*2, channel.TotalRelays)
+
+

--- a/PeerCastStation/PeerCastStation.Test/PeerCastStation.Test.fsproj
+++ b/PeerCastStation/PeerCastStation.Test/PeerCastStation.Test.fsproj
@@ -36,6 +36,7 @@
 
   <ItemGroup>
     <Compile Include="TestCommon.fs" />
+    <Compile Include="CoreTests.fs" />
     <Compile Include="HttpTests.fs" />
     <Compile Include="Tests.fs" />
     <Compile Include="PCPTests.fs" />


### PR DESCRIPTION
チャンネルの合計リレー・視聴数として直下のローカルリレー・視聴数までの合計しかしていなかったので、全ノードのローカルリレー・視聴数を合計するように戻した。