### PR TITLE
リレー管理の改善をした

### DIFF
--- a/PeerCastStation/PeerCastStation.PCP/PCPOutputStream.cs
+++ b/PeerCastStation/PeerCastStation.PCP/PCPOutputStream.cs
@@ -309,11 +309,11 @@ namespace PeerCastStation.PCP
         this.logger = logger;
       }
 
-      private class PCPException
+      private class HandshakeErrorException
         : Exception
       {
         public StopReason QuitCode { get; private set; }
-        public PCPException(StopReason code)
+        public HandshakeErrorException(StopReason code)
         {
           QuitCode = code;
         }
@@ -477,52 +477,21 @@ namespace PeerCastStation.PCP
             if (peer==null) {
               logger.Info("Helo has no SessionID");
               //セッションIDが無かった
-              throw new PCPException(StopReason.NotIdentifiedError);
+              throw new HandshakeErrorException(StopReason.NotIdentifiedError);
             }
             else if ((peer.Host.Extra.GetHeloVersion() ?? 0)<1200) {
               logger.Info("Helo version {0} is too old", peer.Host.Extra.GetHeloVersion() ?? 0);
               //クライアントバージョンが無かった、もしくは古すぎ
-              throw new PCPException(StopReason.BadAgentError);
+              throw new HandshakeErrorException(StopReason.BadAgentError);
             }
             else if (isRelayFull) {
               logger.Debug("Handshake succeeded {0}({1}) but relay is full", peer.Host.GlobalEndPoint, peer.Host.SessionID.ToString("N"));
-              {
-                //次に接続するべきホストを送ってQUIT
-                foreach (var node in SelectSourceHosts(remoteEndPoint)) {
-                  if (peer.Host.SessionID==node.SessionID) continue;
-                  var host_atom = new AtomCollection(node.Extra);
-                  var ip = host_atom.FindByName(Atom.PCP_HOST_IP);
-                  while (ip!=null) {
-                    host_atom.Remove(ip);
-                    ip = host_atom.FindByName(Atom.PCP_HOST_IP);
-                  }
-                  var port = host_atom.FindByName(Atom.PCP_HOST_PORT);
-                  while (port!=null) {
-                    host_atom.Remove(port);
-                    port = host_atom.FindByName(Atom.PCP_HOST_PORT);
-                  }
-                  host_atom.SetHostSessionID(node.SessionID);
-                  var globalendpoint = node.GlobalEndPoint ?? new IPEndPoint(IPAddress.Any, 0);
-                  host_atom.AddHostIP(globalendpoint.Address);
-                  host_atom.AddHostPort(globalendpoint.Port);
-                  var localendpoint  = node.LocalEndPoint ?? new IPEndPoint(IPAddress.Any, 0);
-                  host_atom.AddHostIP(localendpoint.Address);
-                  host_atom.AddHostPort(localendpoint.Port);
-                  host_atom.SetHostNumRelays(node.RelayCount);
-                  host_atom.SetHostNumListeners(node.DirectCount);
-                  host_atom.SetHostChannelID(channel.ChannelID);
-                  host_atom.SetHostFlags1(
-                    (node.IsFirewalled ? PCPHostFlags1.Firewalled : PCPHostFlags1.None) |
-                    (node.IsTracker ? PCPHostFlags1.Tracker : PCPHostFlags1.None) |
-                    (node.IsRelayFull ? PCPHostFlags1.None : PCPHostFlags1.Relay) |
-                    (node.IsDirectFull ? PCPHostFlags1.None : PCPHostFlags1.Direct) |
-                    (node.IsReceiving ? PCPHostFlags1.Receiving : PCPHostFlags1.None) |
-                    (node.IsControlFull ? PCPHostFlags1.None : PCPHostFlags1.ControlIn));
-                  await stream.WriteAsync(new Atom(Atom.PCP_HOST, host_atom), cancellationToken).ConfigureAwait(false);
-                  logger.Debug("Sending Node: {0}({1})", globalendpoint, node.SessionID.ToString("N"));
-                }
+              //次に接続するべきホストを送ってQUIT
+              foreach (var node in SelectSourceHosts(remoteEndPoint)) {
+                if (peer.Host.SessionID==node.SessionID) continue;
+                await SendHost(stream, node, cancellationToken).ConfigureAwait(false);
               }
-              throw new PCPException(StopReason.UnavailableError);
+              throw new HandshakeErrorException(StopReason.UnavailableError);
             }
             else {
               logger.Debug("Handshake succeeded {0}({1})", peer.Host.GlobalEndPoint, peer.Host.SessionID.ToString("N"));
@@ -531,6 +500,40 @@ namespace PeerCastStation.PCP
           }
         }
         return peer;
+      }
+
+      private async Task SendHost(Stream stream, Host node, CancellationToken cancellationToken)
+      {
+        var host_atom = new AtomCollection(node.Extra);
+        var ip = host_atom.FindByName(Atom.PCP_HOST_IP);
+        while (ip!=null) {
+          host_atom.Remove(ip);
+          ip = host_atom.FindByName(Atom.PCP_HOST_IP);
+        }
+        var port = host_atom.FindByName(Atom.PCP_HOST_PORT);
+        while (port!=null) {
+          host_atom.Remove(port);
+          port = host_atom.FindByName(Atom.PCP_HOST_PORT);
+        }
+        host_atom.SetHostSessionID(node.SessionID);
+        var globalendpoint = node.GlobalEndPoint ?? new IPEndPoint(IPAddress.Any, 0);
+        host_atom.AddHostIP(globalendpoint.Address);
+        host_atom.AddHostPort(globalendpoint.Port);
+        var localendpoint  = node.LocalEndPoint ?? new IPEndPoint(IPAddress.Any, 0);
+        host_atom.AddHostIP(localendpoint.Address);
+        host_atom.AddHostPort(localendpoint.Port);
+        host_atom.SetHostNumRelays(node.RelayCount);
+        host_atom.SetHostNumListeners(node.DirectCount);
+        host_atom.SetHostChannelID(channel.ChannelID);
+        host_atom.SetHostFlags1(
+          (node.IsFirewalled ? PCPHostFlags1.Firewalled : PCPHostFlags1.None) |
+          (node.IsTracker ? PCPHostFlags1.Tracker : PCPHostFlags1.None) |
+          (node.IsRelayFull ? PCPHostFlags1.None : PCPHostFlags1.Relay) |
+          (node.IsDirectFull ? PCPHostFlags1.None : PCPHostFlags1.Direct) |
+          (node.IsReceiving ? PCPHostFlags1.Receiving : PCPHostFlags1.None) |
+          (node.IsControlFull ? PCPHostFlags1.None : PCPHostFlags1.ControlIn));
+        await stream.WriteAsync(new Atom(Atom.PCP_HOST, host_atom), cancellationToken).ConfigureAwait(false);
+        logger.Debug("Sending Node: {0}({1})", globalendpoint, node.SessionID.ToString("N"));
       }
 
       private Task OnPCPHelo(Stream stream, ChannelSink sink, Atom atom, CancellationToken cancel_token)
@@ -804,10 +807,10 @@ namespace PeerCastStation.PCP
             try {
               peer = await DoHandshake(stream, remoteEndPoint, isRelayFull, handshakeCT.Token).ConfigureAwait(false);
             }
-            catch (TaskCanceledException) {
+            catch (OperationCanceledException) {
               if (!cancellationToken.IsCancellationRequested) {
                 logger.Info("Handshake timed out.");
-                throw new PCPException(StopReason.BadAgentError);
+                throw new HandshakeErrorException(StopReason.BadAgentError);
               }
               else {
                 throw;
@@ -825,14 +828,15 @@ namespace PeerCastStation.PCP
               ).ConfigureAwait(false);
             }
           }
-          catch (TaskCanceledException) {
+          catch (OperationCanceledException) {
           }
+          await BeforeQuitAsync(stream, sink, cancellationToken).ConfigureAwait(false);
           await SendQuit(stream, sink.StopReason, cancellationToken).ConfigureAwait(false);
         }
-        catch (TaskCanceledException) {
+        catch (OperationCanceledException) {
           await SendQuit(stream, StopReason.OffAir, cancellationToken).ConfigureAwait(false);
         }
-        catch (PCPException e) {
+        catch (HandshakeErrorException e) {
           await SendQuit(stream, e.QuitCode, cancellationToken).ConfigureAwait(false);
         }
         catch (InvalidDataException e) {
@@ -841,6 +845,17 @@ namespace PeerCastStation.PCP
         }
         catch (IOException e) {
           logger.Info(e);
+        }
+      }
+
+      public async Task BeforeQuitAsync(Stream stream, ChannelSink channelSink, CancellationToken cancellationToken)
+      {
+        if (channelSink.StopReason==StopReason.UnavailableError) {
+          //次に接続するべきホストを送ってQUIT
+          foreach (var node in SelectSourceHosts(channelSink.Peer.RemoteEndPoint)) {
+            if (channelSink.Peer.Host.SessionID==node.SessionID) continue;
+            await SendHost(stream, node, cancellationToken).ConfigureAwait(false);
+          }
         }
       }
 

--- a/PeerCastStation/PeerCastStation.PCP/PCPOutputStream.cs
+++ b/PeerCastStation/PeerCastStation.PCP/PCPOutputStream.cs
@@ -800,7 +800,7 @@ namespace PeerCastStation.PCP
 
       public async Task ProcessStream(Stream stream, IPEndPoint remoteEndPoint, long requestPos, CancellationToken cancellationToken)
       {
-        var isRelayFull = !channel.MakeRelayable(remoteEndPoint.Address.IsSiteLocal());
+        var isRelayFull = !channel.MakeRelayable(remoteEndPoint.Address.ToString(), remoteEndPoint.Address.IsSiteLocal());
         PeerInfo peer = null;
         try {
           await stream.WriteBytesAsync(CreateRelayResponse(isRelayFull), cancellationToken).ConfigureAwait(false);
@@ -853,6 +853,8 @@ namespace PeerCastStation.PCP
       public async Task BeforeQuitAsync(Stream stream, ChannelSink channelSink, CancellationToken cancellationToken)
       {
         if (channelSink.StopReason==StopReason.UnavailableError) {
+          //一定時間BANする
+          channel.Ban(channelSink.Peer.RemoteEndPoint.Address.ToString(), DateTimeOffset.Now.AddSeconds(90));
           //次に接続するべきホストを送ってQUIT
           foreach (var node in SelectSourceHosts(channelSink.Peer.RemoteEndPoint)) {
             if (channelSink.Peer.Host.SessionID==node.SessionID) continue;

--- a/PeerCastStation/PeerCastStation.PCP/PCPOutputStream.cs
+++ b/PeerCastStation/PeerCastStation.PCP/PCPOutputStream.cs
@@ -422,6 +422,7 @@ namespace PeerCastStation.PCP
       {
         switch (code) {
         case StopReason.None:
+        case StopReason.UserReconnect:
           break;
         case StopReason.Any:
           await stream.WriteAsync(new Atom(Atom.PCP_QUIT, Atom.PCP_ERROR_QUIT), cancellationToken).ConfigureAwait(false);
@@ -441,6 +442,7 @@ namespace PeerCastStation.PCP
         case StopReason.UnavailableError:
           await stream.WriteAsync(new Atom(Atom.PCP_QUIT, Atom.PCP_ERROR_QUIT + Atom.PCP_ERROR_UNAVAILABLE), cancellationToken).ConfigureAwait(false);
           break;
+        case StopReason.NoHost:
         case StopReason.OffAir:
           await stream.WriteAsync(new Atom(Atom.PCP_QUIT, Atom.PCP_ERROR_QUIT + Atom.PCP_ERROR_OFFAIR), cancellationToken).ConfigureAwait(false);
           break;
@@ -855,6 +857,27 @@ namespace PeerCastStation.PCP
           foreach (var node in SelectSourceHosts(channelSink.Peer.RemoteEndPoint)) {
             if (channelSink.Peer.Host.SessionID==node.SessionID) continue;
             await SendHost(stream, node, cancellationToken).ConfigureAwait(false);
+          }
+        }
+        if (channelSink.StopReason==StopReason.UserShutdown) {
+          //つながっていたホストを送ってQUIT
+          var src = channel.SourceStream?.GetConnectionInfo();
+          if (!channel.IsBroadcasting &&
+              src!=null &&
+              src.RemoteEndPoint!=null &&
+              src.RemoteEndPoint.Address.GetAddressLocality()>=2 &&
+              src.RemoteSessionID.HasValue &&
+              src.RemoteSessionID.Value!=Guid.Empty) {
+            var node = new HostBuilder();
+            node.SessionID = src.RemoteSessionID.Value;
+            node.GlobalEndPoint = src.RemoteEndPoint;
+            node.IsReceiving = true;
+            node.IsFirewalled = false;
+            node.IsControlFull = false;
+            node.IsDirectFull = false;
+            node.IsRelayFull = false;
+            node.IsTracker = false;
+            await SendHost(stream, node.ToHost(), cancellationToken).ConfigureAwait(false);
           }
         }
       }

--- a/PeerCastStation/PeerCastStation.Test/ChannelTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/ChannelTests.fs
@@ -92,4 +92,25 @@ let ``チャンネルがいっぱいの時にMakeRelayableで切れる分を切�
     Assert.Equal(false, channel.MakeRelayable(false))
     Assert.Equal(4, channel.LocalRelays)
 
+[<Fact>]
+let ``指定したキーをBanするとHasBannedがtrueを返す`` () =
+    use peca = new PeerCast()
+    let channel1 = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid())
+    let channel2 = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid())
+    channel1.Ban("hoge", DateTimeOffset.Now.AddMilliseconds(100.0))
+    channel2.Ban("fuga", DateTimeOffset.Now.AddMilliseconds(100.0))
+    channel1.Ban("piyo", DateTimeOffset.Now.AddMilliseconds(100.0))
+    Assert.True(channel1.HasBanned("hoge"))
+    Assert.False(channel1.HasBanned("fuga"))
+    Assert.True(channel1.HasBanned("piyo"))
+    Assert.False(channel2.HasBanned("hoge"))
+    Assert.True(channel2.HasBanned("fuga"))
+    Assert.False(channel2.HasBanned("piyo"))
+    Threading.Thread.Sleep(100);
+    Assert.False(channel1.HasBanned("hoge"))
+    Assert.False(channel1.HasBanned("fuga"))
+    Assert.False(channel1.HasBanned("piyo"))
+    Assert.False(channel2.HasBanned("hoge"))
+    Assert.False(channel2.HasBanned("fuga"))
+    Assert.False(channel2.HasBanned("piyo"))
 

--- a/PeerCastStation/PeerCastStation.Test/ChannelTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/ChannelTests.fs
@@ -1,0 +1,95 @@
+﻿module ChannelTests
+
+open Xunit
+open System
+open PeerCastStation.Core
+open TestCommon
+
+[<Fact>]
+let ``チャンネルがリレー可能な時にMakeRelayableを呼んでもリレー不能なChannelSinkが止められない`` () =
+    use peca = new PeerCast()
+    peca.AccessController.MaxUpstreamRate <- 6000
+    let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid())
+    channel.ChannelInfo <- createChannelInfoBitrate "hoge" "FLV" 500
+    peca.AddChannel(channel)
+    let relays =
+        [| 0; 1; 1; 2; 3; 0 |]
+        |> Seq.map (fun i ->
+            {
+                new IChannelSink with
+                    member this.OnBroadcast(from, packet) = ()
+                    member this.OnStopped(reason) = ()
+                    member this.GetConnectionInfo() =
+                        let info = ConnectionInfoBuilder()
+                        info.Type <- ConnectionType.Relay
+                        info.LocalDirects <- Some i |> Option.toNullable
+                        info.LocalRelays <- Some i |> Option.toNullable
+                        info.RemoteHostStatus <- RemoteHostStatus.RelayFull
+                        info.Build()
+            }
+        )
+        |> Seq.map channel.AddOutputStream 
+        |> Seq.toArray
+    Assert.Equal(6, channel.LocalRelays)
+    Assert.Equal(true, channel.MakeRelayable(false))
+    Assert.Equal(6, channel.LocalRelays)
+
+[<Fact>]
+let ``チャンネルがいっぱいの時にMakeRelayableで必要な分だけChannelSinkを止める`` () =
+    use peca = new PeerCast()
+    peca.AccessController.MaxUpstreamRate <- 3000
+    let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid())
+    channel.ChannelInfo <- createChannelInfoBitrate "hoge" "FLV" 500
+    peca.AddChannel(channel)
+    let relays =
+        [| 0; 1; 1; 2; 3; 0 |]
+        |> Seq.map (fun i ->
+            {
+                new IChannelSink with
+                    member this.OnBroadcast(from, packet) = ()
+                    member this.OnStopped(reason) = ()
+                    member this.GetConnectionInfo() =
+                        let info = ConnectionInfoBuilder()
+                        info.Type <- ConnectionType.Relay
+                        info.LocalDirects <- Some i |> Option.toNullable
+                        info.LocalRelays <- Some i |> Option.toNullable
+                        info.RemoteHostStatus <- RemoteHostStatus.RelayFull
+                        info.Build()
+            }
+        )
+        |> Seq.map channel.AddOutputStream 
+        |> Seq.toArray
+    Assert.Equal(6, channel.LocalRelays)
+    Assert.Equal(true, channel.MakeRelayable(false))
+    Assert.Equal(5, channel.LocalRelays)
+
+[<Fact>]
+let ``チャンネルがいっぱいの時にMakeRelayableで切れる分を切っても新しくリレーできない場合はfalseを返す`` () =
+    use peca = new PeerCast()
+    peca.AccessController.MaxUpstreamRate <- 2000
+    let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid())
+    channel.ChannelInfo <- createChannelInfoBitrate "hoge" "FLV" 500
+    peca.AddChannel(channel)
+    let relays =
+        [| 0; 1; 1; 2; 3; 0 |]
+        |> Seq.map (fun i ->
+            {
+                new IChannelSink with
+                    member this.OnBroadcast(from, packet) = ()
+                    member this.OnStopped(reason) = ()
+                    member this.GetConnectionInfo() =
+                        let info = ConnectionInfoBuilder()
+                        info.Type <- ConnectionType.Relay
+                        info.LocalDirects <- Some i |> Option.toNullable
+                        info.LocalRelays <- Some i |> Option.toNullable
+                        info.RemoteHostStatus <- RemoteHostStatus.RelayFull
+                        info.Build()
+            }
+        )
+        |> Seq.map channel.AddOutputStream 
+        |> Seq.toArray
+    Assert.Equal(6, channel.LocalRelays)
+    Assert.Equal(false, channel.MakeRelayable(false))
+    Assert.Equal(4, channel.LocalRelays)
+
+

--- a/PeerCastStation/PeerCastStation.Test/PeerCastStation.Test.fsproj
+++ b/PeerCastStation/PeerCastStation.Test/PeerCastStation.Test.fsproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <Compile Include="TestCommon.fs" />
     <Compile Include="CoreTests.fs" />
+    <Compile Include="ChannelTests.fs" />
     <Compile Include="HttpTests.fs" />
     <Compile Include="Tests.fs" />
     <Compile Include="PCPTests.fs" />

--- a/PeerCastStation/PeerCastStation.Test/TestCommon.fs
+++ b/PeerCastStation/PeerCastStation.Test/TestCommon.fs
@@ -61,6 +61,13 @@ let createChannelInfo name contentType =
     info.SetChanInfoType contentType
     ChannelInfo info
 
+let createChannelInfoBitrate name contentType bitrate =
+    let info = AtomCollection()
+    info.SetChanInfoName name
+    info.SetChanInfoType contentType
+    info.SetChanInfoBitrate bitrate
+    ChannelInfo info
+
 let registerApp path appFunc (owinHost:PeerCastStation.Core.Http.OwinHost) =
     owinHost.Register(
         fun builder ->


### PR DESCRIPTION
下流のリレーを切断した時の処理についていろいろ改善を追加した

* リレーがいっぱいのチャンネルをリレー可能にする時に、リレー不能なノードを必要分だけ切るようにした e109836
* リレー接続ががUnavailableで終了した時には他のリレー候補を返して切るようにした ded9917
* リレーを切る時に一つ上流の情報を下流に流してから切るようにした 8f73658
* リレーできなくて切った接続は一定時間BANするようにした 51e0266 #436