### PR TITLE
チャンネルとPeerCastのイベントを削除する

### DIFF
--- a/PeerCastStation/PeerCastStation.App/ChannelNotifier.cs
+++ b/PeerCastStation/PeerCastStation.App/ChannelNotifier.cs
@@ -20,9 +20,6 @@ namespace PeerCastStation.App
     {
       this.app = app;
       this.messageExpireTimer.Start();
-      this.app.PeerCast.ChannelAdded += (sender, args) => {
-        args.Channel.AddMonitor(new Monitor(this, args.Channel));
-      };
     }
 
     class Monitor
@@ -91,6 +88,16 @@ namespace PeerCastStation.App
     public void OnTimer()
     {
     }
+
+    public void OnChannelChanged(PeerCastChannelAction action, Channel channel)
+    {
+      switch (action) {
+      case PeerCastChannelAction.Added:
+        channel.AddMonitor(new Monitor(this, channel));
+        break;
+      }
+    }
+
   }
 
 }

--- a/PeerCastStation/PeerCastStation.App/ChannelNotifier.cs
+++ b/PeerCastStation/PeerCastStation.App/ChannelNotifier.cs
@@ -6,7 +6,7 @@ using PeerCastStation.Core;
 namespace PeerCastStation.App
 {
   public class ChannelNotifier
-    : IChannelMonitor
+    : IPeerCastMonitor
   {
     private static TimeSpan messageExpires = TimeSpan.FromMinutes(1);
     public static TimeSpan MessageExpires {
@@ -20,18 +20,39 @@ namespace PeerCastStation.App
     {
       this.app = app;
       this.messageExpireTimer.Start();
-      this.app.PeerCast.ChannelAdded   += (sender, args) => {
-        args.Channel.Closed += OnChannelClosed;
-      };
-      this.app.PeerCast.ChannelRemoved += (sender, args) => {
-        args.Channel.Closed -= OnChannelClosed;
+      this.app.PeerCast.ChannelAdded += (sender, args) => {
+        args.Channel.AddMonitor(new Monitor(this, args.Channel));
       };
     }
 
-    public void OnChannelClosed(object sender, StreamStoppedEventArgs args)
+    class Monitor
+      : IChannelMonitor
     {
-      var channel = (Channel)sender;
-      switch (args.StopReason) {
+      public Channel Channel { get; }
+      public ChannelNotifier Owner { get; }
+      public Monitor(ChannelNotifier owner, Channel channel)
+      {
+        Owner = owner;
+        Channel = channel;
+      }
+
+      public void OnContentChanged(ChannelContentType channelContentType)
+      {
+      }
+
+      public void OnNodeChanged(ChannelNodeAction action, Host node)
+      {
+      }
+
+      public void OnStopped(StopReason reason)
+      {
+        Owner.OnChannelClosed(Channel, reason);
+      }
+    }
+
+    private void OnChannelClosed(Channel channel, StopReason reason)
+    {
+      switch (reason) {
       case StopReason.OffAir: {
           var msg = new NotificationMessage(
             channel.ChannelInfo.Name,
@@ -71,4 +92,5 @@ namespace PeerCastStation.App
     {
     }
   }
+
 }

--- a/PeerCastStation/PeerCastStation.Core/Channel.cs
+++ b/PeerCastStation/PeerCastStation.Core/Channel.cs
@@ -141,8 +141,6 @@ namespace PeerCastStation.Core
       get { return sinks; }
     }
 
-    public event EventHandler OutputStreamsChanged;
-
     private void ReplaceCollection<T>(ref T collection, Func<T,T> newcollection_func) where T : class
     {
       bool replaced = false;
@@ -183,7 +181,6 @@ namespace PeerCastStation.Core
     public IDisposable AddOutputStream(IChannelSink stream)
     {
       ReplaceCollection(ref sinks, old => old.Add(stream));
-      OutputStreamsChanged?.Invoke(this, new EventArgs());
       return new ChannelSinkSubscription { Channel=this, Sink=stream };
     }
 
@@ -194,7 +191,6 @@ namespace PeerCastStation.Core
     public void RemoveOutputStream(IChannelSink stream)
     {
       ReplaceCollection(ref sinks, old => old.Remove(stream));
-      OutputStreamsChanged?.Invoke(this, new EventArgs());
     }
 
     public int GetUpstreamRate()
@@ -222,7 +218,6 @@ namespace PeerCastStation.Core
       }
     }
 
-    public event EventHandler<ChannelInfoEventArgs> ChannelInfoChanged;
     private ChannelInfo channelInfo = new ChannelInfo(new AtomCollection());
     /// <summary>
     /// チャンネル情報を取得および設定します
@@ -249,7 +244,6 @@ namespace PeerCastStation.Core
       }
     }
 
-    public event EventHandler<ChannelTrackEventArgs> ChannelTrackChanged;
     private ChannelTrack channelTrack = new ChannelTrack(new AtomCollection());
     /// <summary>
     /// トラック情報を取得および設定します
@@ -478,45 +472,6 @@ namespace PeerCastStation.Core
         sink.OnContent(content);
       });
     }
-
-    class ChannelEventInvoker
-      : IContentSink
-    {
-      private Channel owner;
-      public ChannelEventInvoker(Channel owner)
-      {
-        this.owner = owner;
-      }
-
-      public void OnChannelInfo(ChannelInfo channel_info)
-      {
-        owner.ChannelInfoChanged?.Invoke(owner, new ChannelInfoEventArgs(channel_info));
-      }
-
-      public void OnChannelTrack(ChannelTrack channel_track)
-      {
-        owner.ChannelTrackChanged?.Invoke(owner, new ChannelTrackEventArgs(channel_track));
-      }
-
-      public void OnContent(Content content)
-      {
-        owner.ContentChanged?.Invoke(owner, new EventArgs());
-      }
-
-      public void OnContentHeader(Content content_header)
-      {
-        owner.ContentChanged?.Invoke(owner, new EventArgs());
-      }
-
-      public void OnStop(StopReason reason)
-      {
-      }
-    }
-
-    /// <summary>
-    /// コンテントが追加および削除された時に発生するイベントです
-    /// </summary>
-    public event EventHandler ContentChanged;
 
     /// <summary>
     /// 保持している最後のコンテントの次のバイト位置を取得します
@@ -800,24 +755,47 @@ namespace PeerCastStation.Core
       }
     }
 
-    public async Task WaitForReadyContentTypeAsync(CancellationToken cancel_token)
+    class ChannelInfoMonitor
+      : IChannelMonitor
     {
-      var task = new TaskCompletionSource<bool>();
-      using (cancel_token.Register(() => task.TrySetCanceled(), false)) {
-        var channel_info_changed = new EventHandler<ChannelInfoEventArgs>((sender, e) => {
-          if (e.ChannelInfo!=null && !String.IsNullOrEmpty(e.ChannelInfo.ContentType)) {
-            task.TrySetResult(true);
-          }
-        });
-        try {
-          this.ChannelInfoChanged += channel_info_changed;
-          var channel_info = this.ChannelInfo;
-          if (channel_info!=null && !String.IsNullOrEmpty(channel_info.ContentType)) return;
+      Channel Channel { get; }
+      TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
+
+      public ChannelInfoMonitor(Channel channel)
+      {
+        Channel = channel;
+      }
+
+      public async Task WaitForReadyAsync(CancellationToken cancellationToken)
+      {
+        using (cancellationToken.Register(() => task.TrySetCanceled())) {
           await task.Task.ConfigureAwait(false);
         }
-        finally {
-          this.ChannelInfoChanged -= channel_info_changed;
+      }
+
+      public void OnContentChanged(ChannelContentType channelContentType)
+      {
+        if (channelContentType!=ChannelContentType.ChannelInfo) return;
+        if (!String.IsNullOrEmpty(Channel.ChannelInfo?.ContentType)) {
+          task.TrySetResult(true);
         }
+      }
+
+      public void OnNodeChanged(ChannelNodeAction action, Host node)
+      {
+      }
+
+      public void OnStopped(StopReason reason)
+      {
+      }
+    }
+
+    public async Task WaitForReadyContentTypeAsync(CancellationToken cancel_token)
+    {
+      var monitor = new ChannelInfoMonitor(this);
+      using (AddMonitor(monitor)) {
+        if (!String.IsNullOrEmpty(ChannelInfo?.ContentType)) return;
+        await monitor.WaitForReadyAsync(cancel_token).ConfigureAwait(false);
       }
     }
 
@@ -852,7 +830,7 @@ namespace PeerCastStation.Core
       this.Network     = network;
       this.ChannelID   = channel_id;
       this.contents    = new ContentCollection(this);
-      this.contentSinks = ImmutableArray.Create<IContentSink>(new ChannelEventInvoker(this));
+      this.contentSinks = ImmutableArray<IContentSink>.Empty;
     }
   }
 

--- a/PeerCastStation/PeerCastStation.Core/ChannelCleaner.cs
+++ b/PeerCastStation/PeerCastStation.Core/ChannelCleaner.cs
@@ -6,7 +6,7 @@ using PeerCastStation.Core;
 namespace PeerCastStation
 {
   public class ChannelCleaner
-    : IChannelMonitor
+    : IPeerCastMonitor
   {
     private Dictionary<Channel, int> inactiveChannels  = new Dictionary<Channel,int>();
     private PeerCast peerCast;

--- a/PeerCastStation/PeerCastStation.Core/ChannelCleaner.cs
+++ b/PeerCastStation/PeerCastStation.Core/ChannelCleaner.cs
@@ -86,6 +86,11 @@ namespace PeerCastStation
         break;
       }
     }
+
+    public void OnChannelChanged(PeerCastChannelAction action, Channel channel)
+    {
+    }
+
   }
 
 }

--- a/PeerCastStation/PeerCastStation.Core/Core.cs
+++ b/PeerCastStation/PeerCastStation.Core/Core.cs
@@ -737,11 +737,24 @@ namespace PeerCastStation.Core
     IContentSink Activate(IContentSink sink);
   }
 
+
+  public enum PeerCastChannelAction
+  {
+    Added,
+    Removed,
+  }
+
   /// <summary>
   /// PeerCastオブジェクト内のいろいろを監視して管理するためのオブジェクトのインターフェースです
   /// </summary>
   public interface IPeerCastMonitor
   {
+    /// <summary>
+    /// PeerCastオブジェクトのチャンネルが変更された時に呼び出されます
+    /// </summary>
+    /// <param name="action">変更内容</param>
+    /// <param name="channel">変更されたチャンネル</param>
+    void OnChannelChanged(PeerCastChannelAction action, Channel channel);
     /// <summary>
     /// 定期的に呼び出されるメソッドです
     /// </summary>

--- a/PeerCastStation/PeerCastStation.Core/Core.cs
+++ b/PeerCastStation/PeerCastStation.Core/Core.cs
@@ -510,6 +510,17 @@ namespace PeerCastStation.Core
     ISourceStream Create(Channel channel, Uri source, IContentReader reader);
   }
 
+  public enum ChannelNodeAction
+  {
+    Updated,
+    Removed,
+  }
+
+  public interface IChannelSource
+  {
+    void OnNodeChanged(ChannelNodeAction action, Host node);
+  }
+
   public enum HandlerResult {
     Close    =  0,
     Continue =  1,

--- a/PeerCastStation/PeerCastStation.Core/Core.cs
+++ b/PeerCastStation/PeerCastStation.Core/Core.cs
@@ -516,9 +516,18 @@ namespace PeerCastStation.Core
     Removed,
   }
 
-  public interface IChannelSource
+  public enum ChannelContentType
   {
+    ChannelInfo,
+    ChannelTrack,
+    ContentHeader,
+  }
+
+  public interface IChannelMonitor
+  {
+    void OnContentChanged(ChannelContentType channelContentType);
     void OnNodeChanged(ChannelNodeAction action, Host node);
+    void OnStopped(StopReason reason);
   }
 
   public enum HandlerResult {
@@ -729,9 +738,9 @@ namespace PeerCastStation.Core
   }
 
   /// <summary>
-  /// チャンネルを監視して管理するためのオブジェクトのインターフェースです
+  /// PeerCastオブジェクト内のいろいろを監視して管理するためのオブジェクトのインターフェースです
   /// </summary>
-  public interface IChannelMonitor
+  public interface IPeerCastMonitor
   {
     /// <summary>
     /// 定期的に呼び出されるメソッドです

--- a/PeerCastStation/PeerCastStation.Core/PeerCast.cs
+++ b/PeerCastStation/PeerCastStation.Core/PeerCast.cs
@@ -133,8 +133,8 @@ namespace PeerCastStation.Core
     /// <summary>
     /// チャンネル管理オブジェクトのリストを取得します
     /// </summary>
-    public ReadOnlyCollection<IChannelMonitor> ChannelMonitors { get { return channelMonitors.AsReadOnly(); } }
-    private List<IChannelMonitor> channelMonitors = new List<IChannelMonitor>();
+    public ReadOnlyCollection<IPeerCastMonitor> ChannelMonitors { get { return channelMonitors.AsReadOnly(); } }
+    private List<IPeerCastMonitor> channelMonitors = new List<IPeerCastMonitor>();
 
     /// <summary>
     /// チャンネルが追加された時に呼び出されます。
@@ -369,19 +369,19 @@ namespace PeerCastStation.Core
       monitorTask = StartMonitor(cancelSource.Token);
     }
 
-		public void AddChannelMonitor(IChannelMonitor monitor)
+		public void AddChannelMonitor(IPeerCastMonitor monitor)
 		{
 			ReplaceCollection(ref channelMonitors, orig => {
-				var new_monitors = new List<IChannelMonitor>(orig);
+				var new_monitors = new List<IPeerCastMonitor>(orig);
 				new_monitors.Add(monitor);
 				return new_monitors;
 			});
 		}
 
-		public void RemoveChannelMonitor(IChannelMonitor monitor)
+		public void RemoveChannelMonitor(IPeerCastMonitor monitor)
 		{
 			ReplaceCollection(ref channelMonitors, orig => {
-				var new_monitors = new List<IChannelMonitor>(orig);
+				var new_monitors = new List<IPeerCastMonitor>(orig);
 				new_monitors.Remove(monitor);
 				return new_monitors;
 			});

--- a/PeerCastStation/PeerCastStation.Core/PeerCast.cs
+++ b/PeerCastStation/PeerCastStation.Core/PeerCast.cs
@@ -86,7 +86,6 @@ namespace PeerCastStation.Core
         ReplaceCollection(ref yellowPages, org => {
           return new List<IYellowPageClient>(value);
         });
-        YellowPagesChanged(this, new EventArgs());
       }
     }
     private List<IYellowPageClient> yellowPages = new List<IYellowPageClient>();
@@ -100,11 +99,6 @@ namespace PeerCastStation.Core
         goto retry;
       }
     }
-
-    /// <summary>
-    /// YPリストが変更された時に呼び出されます。
-    /// </summary>
-    public event EventHandler YellowPagesChanged;
 
     /// <summary>
     /// 登録されているYellowPageファクトリのリストを取得します
@@ -131,19 +125,14 @@ namespace PeerCastStation.Core
     private List<Channel> channels = new List<Channel>();
 
     /// <summary>
-    /// チャンネル管理オブジェクトのリストを取得します
+    /// 監視オブジェクトのリストを取得します
     /// </summary>
-    public ReadOnlyCollection<IPeerCastMonitor> ChannelMonitors { get { return channelMonitors.AsReadOnly(); } }
-    private List<IPeerCastMonitor> channelMonitors = new List<IPeerCastMonitor>();
+    public ReadOnlyCollection<IPeerCastMonitor> Monitors { get { return monitors.AsReadOnly(); } }
+    private List<IPeerCastMonitor> monitors = new List<IPeerCastMonitor>();
+    private readonly Timer monitorTimer;
 
-    /// <summary>
-    /// チャンネルが追加された時に呼び出されます。
-    /// </summary>
-    public event ChannelChangedEventHandler ChannelAdded;
-    /// <summary>
-    /// チャンネルが削除された時に呼び出されます。
-    /// </summary>
-    public event ChannelChangedEventHandler ChannelRemoved;
+    private CancellationTokenSource cancelSource = new CancellationTokenSource();
+    private Task monitorTask = Task.Delay(0);
 
     /// <summary>
     /// チャンネルへのアクセス制御を行なうクラスの取得および設定をします
@@ -199,7 +188,7 @@ namespace PeerCastStation.Core
         new_collection.Add(channel);
         return new_collection;
       });
-      if (ChannelAdded!=null) ChannelAdded(this, new ChannelChangedEventArgs(channel));
+      DispatchMonitorEvent(mon => mon.OnChannelChanged(PeerCastChannelAction.Added, channel));
       return channel;
     }
 
@@ -264,7 +253,7 @@ namespace PeerCastStation.Core
         new_collection.Add(channel);
         return new_collection;
       });
-      if (ChannelAdded!=null) ChannelAdded(this, new ChannelChangedEventArgs(channel));
+      DispatchMonitorEvent(mon => mon.OnChannelChanged(PeerCastChannelAction.Added, channel));
       if (yp!=null) yp.Announce(channel);
       return channel;
     }
@@ -295,7 +284,7 @@ namespace PeerCastStation.Core
         return new_channels;
       });
       logger.Debug("Channel Removed: {0}", channel.ChannelID.ToString("N"));
-      if (ChannelRemoved!=null) ChannelRemoved(this, new ChannelChangedEventArgs(channel));
+      DispatchMonitorEvent(mon => mon.OnChannelChanged(PeerCastChannelAction.Removed, channel));
     }
 
     /// <summary>
@@ -323,7 +312,6 @@ namespace PeerCastStation.Core
         return new_yps;
       });
       logger.Debug("YP Added: {0}", yp.Name);
-      if (YellowPagesChanged!=null) YellowPagesChanged(this, new EventArgs());
       return yp;
     }
 
@@ -340,11 +328,8 @@ namespace PeerCastStation.Core
         return new_yps;
       });
       logger.Debug("YP Removed: {0}", yp.Name);
-      if (YellowPagesChanged!=null) YellowPagesChanged(this, new EventArgs());
     }
 
-    private CancellationTokenSource cancelSource = new CancellationTokenSource();
-    private Task monitorTask = null;
     /// <summary>
     /// PeerCastを初期化します
     /// </summary>
@@ -366,12 +351,36 @@ namespace PeerCastStation.Core
       this.OutputStreamFactories = new List<IOutputStreamFactory>();
       this.ContentReaderFactories = new List<IContentReaderFactory>();
       this.ContentFilters = new List<IContentFilter>();
-      monitorTask = StartMonitor(cancelSource.Token);
+      this.monitorTimer = new Timer(OnMonitorTimer, cancelSource.Token, 0, 5000);
+    }
+
+    private void OnMonitorTimer(object state)
+    {
+      var cs = (CancellationToken)state;
+      if (!cs.IsCancellationRequested) {
+        DispatchMonitorEvent(mon => mon.OnTimer(), cs);
+      }
+    }
+
+    private void DispatchMonitorEvent(Action<IPeerCastMonitor> monitorAction)
+    {
+      var monitors = this.monitors;
+      monitorTask = monitorTask.ContinueWith(prev => {
+        monitors.AsParallel().ForAll(monitorAction);
+      });
+    }
+
+    private void DispatchMonitorEvent(Action<IPeerCastMonitor> monitorAction, CancellationToken cs)
+    {
+      var monitors = this.monitors;
+      monitorTask = monitorTask.ContinueWith(prev => {
+        monitors.AsParallel().ForAll(monitorAction);
+      }, cs);
     }
 
 		public void AddChannelMonitor(IPeerCastMonitor monitor)
 		{
-			ReplaceCollection(ref channelMonitors, orig => {
+			ReplaceCollection(ref monitors, orig => {
 				var new_monitors = new List<IPeerCastMonitor>(orig);
 				new_monitors.Add(monitor);
 				return new_monitors;
@@ -380,7 +389,7 @@ namespace PeerCastStation.Core
 
 		public void RemoveChannelMonitor(IPeerCastMonitor monitor)
 		{
-			ReplaceCollection(ref channelMonitors, orig => {
+			ReplaceCollection(ref monitors, orig => {
 				var new_monitors = new List<IPeerCastMonitor>(orig);
 				new_monitors.Remove(monitor);
 				return new_monitors;
@@ -391,7 +400,7 @@ namespace PeerCastStation.Core
     {
       try {
         while (!cancel_token.IsCancellationRequested) {
-          foreach (var monitor in ChannelMonitors) {
+          foreach (var monitor in monitors) {
             monitor.OnTimer();
           }
           await Task.Delay(5000, cancel_token).ConfigureAwait(false);
@@ -639,12 +648,13 @@ namespace PeerCastStation.Core
     {
       logger.Info("Stopping PeerCast");
       cancelSource.Cancel();
+      monitorTimer.Dispose();
       foreach (var listener in outputListeners) {
         listener.Stop();
       }
       foreach (var channel in channels) {
         channel.Close();
-        if (ChannelRemoved!=null) ChannelRemoved(this, new ChannelChangedEventArgs(channel));
+        DispatchMonitorEvent(mon => mon.OnChannelChanged(PeerCastChannelAction.Removed, channel));
       }
       foreach (var ypclient in yellowPages) {
         ypclient.StopAnnounce();

--- a/PeerCastStation/PeerCastStation.Test/ChannelTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/ChannelTests.fs
@@ -4,6 +4,7 @@ open Xunit
 open System
 open PeerCastStation.Core
 open TestCommon
+open System.Net
 
 [<Fact>]
 let ``チャンネルがリレー可能な時にMakeRelayableを呼んでもリレー不能なChannelSinkが止められない`` () =
@@ -113,4 +114,28 @@ let ``指定したキーをBanするとHasBannedがtrueを返す`` () =
     Assert.False(channel2.HasBanned("hoge"))
     Assert.False(channel2.HasBanned("fuga"))
     Assert.False(channel2.HasBanned("piyo"))
+
+[<Fact>]
+let ``ノード情報が変更されるとIChannelSourceのOnNodeChangedが呼び出される`` () =
+    use peca = new PeerCast()
+    let mutable nodes = []
+    let createSource _ =
+        {
+            new DummySourceStream(SourceStreamType.Relay) 
+                interface IChannelSource with
+                    member this.OnNodeChanged(action, node) =
+                        nodes <- (action, node) :: nodes
+                        ()
+        } :> ISourceStream
+    let channel = DummyRelayChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createSource)
+    channel.Start null
+    peca.AddChannel channel
+    let hosts = 
+        Array.init 32 (fun i -> Host(Guid.NewGuid(), Guid.Empty, IPEndPoint(IPAddress.Loopback, 1234+i), IPEndPoint(IPAddress.Loopback, 1234+i), 1+i, 1+i/2, false, false, false, false, true, false, Seq.empty, AtomCollection()))
+    Array.iter (fun h -> channel.AddNode(h)) hosts
+    Array.iter (fun h -> channel.RemoveNode(h)) hosts
+    System.Threading.Thread.Sleep 100
+    Assert.Equal(64, List.length nodes)
+    Assert.True(Array.forall (fun h -> List.contains (ChannelNodeAction.Updated, h) nodes) hosts)
+    Assert.True(Array.forall (fun h -> List.contains (ChannelNodeAction.Removed, h) nodes) hosts)
 

--- a/PeerCastStation/PeerCastStation.Test/ChannelTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/ChannelTests.fs
@@ -116,19 +116,21 @@ let ``指定したキーをBanするとHasBannedがtrueを返す`` () =
     Assert.False(channel2.HasBanned("piyo"))
 
 [<Fact>]
-let ``ノード情報が変更されるとIChannelSourceのOnNodeChangedが呼び出される`` () =
+let ``ノード情報が変更されるとIChannelMonitorのOnNodeChangedが呼び出される`` () =
     use peca = new PeerCast()
     let mutable nodes = []
-    let createSource _ =
-        {
-            new DummySourceStream(SourceStreamType.Relay) 
-                interface IChannelSource with
-                    member this.OnNodeChanged(action, node) =
-                        nodes <- (action, node) :: nodes
-                        ()
-        } :> ISourceStream
-    let channel = DummyRelayChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createSource)
-    channel.Start null
+    let monitor = {
+        new IChannelMonitor with
+            member this.OnContentChanged _ = 
+                ()
+            member this.OnStopped _ = 
+                ()
+            member this.OnNodeChanged(action, node) =
+                nodes <- (action, node) :: nodes
+                ()
+    }
+    let channel = DummyRelayChannel(peca, NetworkType.IPv4, Guid.NewGuid())
+    use subscription = channel.AddMonitor monitor
     peca.AddChannel channel
     let hosts = 
         Array.init 32 (fun i -> Host(Guid.NewGuid(), Guid.Empty, IPEndPoint(IPAddress.Loopback, 1234+i), IPEndPoint(IPAddress.Loopback, 1234+i), 1+i, 1+i/2, false, false, false, false, true, false, Seq.empty, AtomCollection()))

--- a/PeerCastStation/PeerCastStation.Test/ChannelTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/ChannelTests.fs
@@ -136,7 +136,13 @@ let ``ノード情報が変更されるとIChannelMonitorのOnNodeChangedが呼�
         Array.init 32 (fun i -> Host(Guid.NewGuid(), Guid.Empty, IPEndPoint(IPAddress.Loopback, 1234+i), IPEndPoint(IPAddress.Loopback, 1234+i), 1+i, 1+i/2, false, false, false, false, true, false, Seq.empty, AtomCollection()))
     Array.iter (fun h -> channel.AddNode(h)) hosts
     Array.iter (fun h -> channel.RemoveNode(h)) hosts
-    System.Threading.Thread.Sleep 100
+    let rec waitForNotEmpty cnt =
+        System.Threading.Thread.Sleep 100
+        if List.isEmpty nodes && cnt>0 then
+            waitForNotEmpty (cnt-1)
+        else
+            ()
+    waitForNotEmpty 10
     Assert.Equal(64, List.length nodes)
     Assert.True(Array.forall (fun h -> List.contains (ChannelNodeAction.Updated, h) nodes) hosts)
     Assert.True(Array.forall (fun h -> List.contains (ChannelNodeAction.Removed, h) nodes) hosts)

--- a/PeerCastStation/PeerCastStation.UI/PortMapperPlugin.cs
+++ b/PeerCastStation/PeerCastStation.UI/PortMapperPlugin.cs
@@ -125,7 +125,7 @@ namespace PeerCastStation.UI
   }
 
   public class PortMapperMonitor
-    : IChannelMonitor,
+    : IPeerCastMonitor,
       IDisposable
   {
     private class NatDevice

--- a/PeerCastStation/PeerCastStation.UI/PortMapperPlugin.cs
+++ b/PeerCastStation/PeerCastStation.UI/PortMapperPlugin.cs
@@ -282,6 +282,10 @@ namespace PeerCastStation.UI
       }
     }
 
+    public void OnChannelChanged(PeerCastChannelAction action, Channel channel)
+    {
+    }
+
   }
 
 }

--- a/PeerCastStation/PeerCastStation.WPF/PeerCastAppViewModel.cs
+++ b/PeerCastStation/PeerCastStation.WPF/PeerCastAppViewModel.cs
@@ -26,7 +26,7 @@ using System.Net.Sockets;
 
 namespace PeerCastStation.WPF
 {
-  class PeerCastAppViewModel : ViewModelBase, IDisposable
+  class PeerCastAppViewModel : ViewModelBase, IDisposable, IPeerCastMonitor
   {
     private readonly PeerCastApplication application;
     public PeerCastApplication Model { get { return application; } }
@@ -82,15 +82,12 @@ namespace PeerCastStation.WPF
       this.application = application;
       var peerCast = application.PeerCast;
       channelList = new ChannelListViewModel(peerCast);
-
-      peerCast.ChannelAdded += OnChannelChanged;
-      peerCast.ChannelRemoved += OnChannelChanged;
+      peerCast.AddChannelMonitor(this);
     }
 
     public void Dispose()
     {
-      application.PeerCast.ChannelAdded   -= OnChannelChanged;
-      application.PeerCast.ChannelRemoved -= OnChannelChanged;
+      application.PeerCast.RemoveChannelMonitor(this);
       log.Dispose();
     }
 
@@ -101,11 +98,15 @@ namespace PeerCastStation.WPF
       log.UpdateLog();
     }
 
-    private void OnChannelChanged(object sender, EventArgs e)
+    public void OnChannelChanged(PeerCastChannelAction action, Channel channel)
     {
       Application.Current.Dispatcher.BeginInvoke(new Action(() => {
         channelList.UpdateChannelList();
       }));
+    }
+
+    public void OnTimer()
+    {
     }
 
     public void OpenBrowserUI()


### PR DESCRIPTION
チャンネルやPeerCastのイベントは購読の登録と解除操作を忘れる可能性があって微妙なので、IChannelMonitorやIPeerCastMonitorのメンバー呼び出しに置き換えたい。