### PR TITLE
HTML UIで再接続した時に接続先のセッションID表示が更新されなかったのを修正した

### DIFF
--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/js/relays.js
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/js/relays.js
@@ -489,6 +489,7 @@ var ChannelConnectionViewModel = function(owner, initial_value) {
     self.remoteEndpoint(value.remoteEndpoint);
     self.remoteHostStatus(value.remoteHostStatus);
     self.remoteName(value.remoteName);
+    self.remoteSessionId(value.remoteSessionId);
     return self;
   };
 


### PR DESCRIPTION
HTML UIで再接続を実行した時に接続先のセッションID表示が更新されなかったのを修正した。