### PR TITLE
WMV配信をMediaFoundationで再生できないバグを修正

### DIFF
--- a/PeerCastStation/PeerCastStation.HTTP/HTTPOutputStream.cs
+++ b/PeerCastStation/PeerCastStation.HTTP/HTTPOutputStream.cs
@@ -314,6 +314,7 @@ namespace PeerCastStation.HTTP
           try {
             while (!ct.IsCancellationRequested) {
               var packet = await sink.DequeueAsync(ct).ConfigureAwait(false);
+              ctx.Response.ContentLength = packet.Content.Data.Length;
               if (packet.Type==ChannelSink.ChannelMessage.MessageType.ContentHeader) {
                 await ctx.Response.WriteAsync(packet.Content.Data, ct).ConfigureAwait(false);
                 logger.Debug("Sent ContentHeader pos {0}", packet.Content.Position);


### PR DESCRIPTION
headerにContent-Lengthが無いのが再生できない原因でした
動作確認はWMV配信をhttptスキームでWMPで開くと動作確認が出来ます