### PR TITLE
HTML UIでYPの追加が正しくできていなかったのを修正する

### DIFF
--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/js/settings.js
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/js/settings.js
@@ -354,7 +354,7 @@ var SettingsViewModel = new function() {
       if (channels_uri==null || channels_uri==="") {
         channels_uri = null;
       }
-      PeerCastStation.addYellowPage(yp.protocol(), yp.name(), announce_uri, channels_uri).then(
+      PeerCastStation.addYellowPage(yp.protocol(), yp.name(), null, announce_uri, channels_uri).then(
         function (res) {
           self.update();
         },
@@ -403,7 +403,7 @@ var SettingsViewModel = new function() {
       if (channels_uri==null || channels_uri==="") {
         channels_uri = null;
       }
-      PeerCastStation.addYellowPage(yp.protocol(), yp.name(), announce_uri, channels_uri).then(
+      PeerCastStation.addYellowPage(yp.protocol(), yp.name(), null, announce_uri, channels_uri).then(
         function (res) {
           PeerCastStation.removeYellowPage(target.id()).then(function () { self.update(); });
         },


### PR DESCRIPTION
JSON-RPCのクライアントを自動生成にした影響でHTML UIでYPの追加が正しくできていなかったのを修正した