### PR TITLE
PCPリレー要求時のハンドシェイクが長時間正しく行われない時にタイムアウトするようにする

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/RelayChannel.cs
+++ b/PeerCastStation/PeerCastStation.Core/RelayChannel.cs
@@ -9,7 +9,6 @@ namespace PeerCastStation.Core
     public override bool IsBroadcasting { get { return false; } }
 
     public RelayChannel(PeerCast peercast, NetworkType network,Guid channel_id)
-        
       : base(peercast, network, channel_id)
     {
     }

--- a/PeerCastStation/PeerCastStation.Core/SourceConnectionBase.cs
+++ b/PeerCastStation/PeerCastStation.Core/SourceConnectionBase.cs
@@ -151,6 +151,7 @@ namespace PeerCastStation.Core
       if (reason==StopReason.UserShutdown && StoppedReason!=reason) StoppedReason = reason;
       if (IsStopped) return;
       StoppedReason = reason;
+      Logger.Debug($"Stop requested by reason {StoppedReason}");
       isStopped.Cancel();
     }
 

--- a/PeerCastStation/PeerCastStation.Core/SourceStreamBase.cs
+++ b/PeerCastStation/PeerCastStation.Core/SourceStreamBase.cs
@@ -200,7 +200,7 @@ namespace PeerCastStation.Core
           var result = await prev.ConfigureAwait(false);
           args.Reason = result;
         }
-        catch (TaskCanceledException) {
+        catch (OperationCanceledException) {
           args.Reason = StopReason.UserShutdown;
         }
         catch (Exception) {

--- a/PeerCastStation/PeerCastStation.Test/PCPTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/PCPTests.fs
@@ -115,14 +115,38 @@ module HTTPClient =
             stream: System.IO.Stream;
         }
 
+    type Request =
+        {
+            method: string;
+            pathAndQuery: string;
+            protocol: string;
+            headers: Map<string,string>;
+            stream: System.IO.Stream;
+        }
+
     let connect endpoint =
         let client = new TcpClient()
         client.Connect(endpoint)
         client
 
+    let listen (endpoint:IPEndPoint) =
+        let server = TcpListener(endpoint)
+        server.Start()
+        async {
+            let! client = server.AcceptTcpClientAsync() |> Async.AwaitTask
+            server.Stop()
+            return client
+        }
+
     let sendGetRequest path headers (client:TcpClient) =
         let stream = client.GetStream()
         Stream.puts (sprintf "GET %s HTTP/1.1" path) stream
+        Map.iter (fun k v -> Stream.puts (sprintf "%s:%s" k v) stream) headers
+        Stream.putsEmpty stream
+
+    let sendResponse status headers (client:TcpClient) =
+        let stream = client.GetStream()
+        Stream.puts (sprintf "HTTP/1.1 %d %s" (int status) (string status)) stream
         Map.iter (fun k v -> Stream.puts (sprintf "%s:%s" k v) stream) headers
         Stream.putsEmpty stream
 
@@ -140,33 +164,55 @@ module HTTPClient =
         else
             None
 
+    let rec recvHeaders stream headers =
+        match Stream.gets stream with
+        | "" ->
+            headers
+        | ParseHeader (k,v) ->
+            headers
+            |> Map.add k v
+            |> recvHeaders stream
+        | _ ->
+            headers
+
     let recvResponse (client:TcpClient) =
         let stream = client.GetStream()
         match Stream.gets stream with
         | ParseResponseLine (protocol, status, reason) ->
-            let rec recvHeaders headers =
-                match Stream.gets stream with
-                | "" ->
-                    headers
-                | ParseHeader (k,v) ->
-                    headers
-                    |> Map.add k v
-                    |> recvHeaders
-                | _ ->
-                    headers
             {
                 protocol=protocol;
                 reasonPhrase=reason;
                 status=status;
-                headers=recvHeaders Map.empty;
+                headers=recvHeaders stream Map.empty;
                 stream=stream
             }
             |> Ok
         | _ ->
             Error "response Error"
 
+    let (|ParseRequestLine|_|) str =
+        let md = System.Text.RegularExpressions.Regex(@"(GET|HEAD|OPTION|POST|PUT|DELETE) (\S+) (HTTP/1.\d)").Match(str)
+        if md.Success then
+            Some (md.Groups.[1].Value.Trim(), md.Groups.[2].Value.Trim(), md.Groups.[3].Value.Trim())
+        else
+            None
 
-type PCPRelayConnection =
+    let recvRequest (client:TcpClient) =
+        let stream = client.GetStream()
+        match Stream.gets stream with
+        | ParseRequestLine (method, pathAndQuery, protocol) ->
+            {
+                protocol=protocol;
+                method=method;
+                pathAndQuery=pathAndQuery;
+                headers=recvHeaders stream Map.empty;
+                stream=stream
+            }
+            |> Ok
+        | _ ->
+            Error "request Error"
+
+type RelayClientConnection =
     {
         endpoint : IPEndPoint;
         channelId : Guid;
@@ -178,7 +224,7 @@ type PCPRelayConnection =
         member this.Dispose() =
             this.connection.Dispose()
 
-module PCPRelayConnection =
+module RelayClientConnection =
     let connect endpoint (channelId: Guid) =
         let client = HTTPClient.connect endpoint
         let headers =
@@ -207,11 +253,11 @@ module PCPRelayConnection =
     let sendAtom value connection =
         connection.response.stream.Write(value)
 
-module RelayTests =
+module RelaySinkTests =
     let endpoint = allocateEndPoint IPAddress.Loopback
 
     let rec recvHost connection hosts =
-        let atom = PCPRelayConnection.recvAtom connection
+        let atom = RelayClientConnection.recvAtom connection
         if atom.Name = Atom.PCP_HOST then
             atom :: hosts
             |> recvHost connection
@@ -227,22 +273,22 @@ module RelayTests =
             waitForOutputStream channel
     
     let expectRelay503 (channel:Channel) =
-        use connection = PCPRelayConnection.connect endpoint channel.ChannelID
+        use connection = RelayClientConnection.connect endpoint channel.ChannelID
         Assert.Equal(503, connection.response.status)
-        PCPRelayConnection.sendHelo connection
-        let oleh = PCPRelayConnection.recvAtom connection
+        RelayClientConnection.sendHelo connection
+        let oleh = RelayClientConnection.recvAtom connection
         Assert.Equal(Atom.PCP_OLEH, oleh.Name)
         let hosts, last = recvHost connection []
         Assert.ExpectAtomName Atom.PCP_QUIT last
         hosts
 
     let expectRelay200 (channel:Channel) stopReason =
-        use connection = PCPRelayConnection.connect endpoint channel.ChannelID
+        use connection = RelayClientConnection.connect endpoint channel.ChannelID
         Assert.Equal(200, connection.response.status)
-        PCPRelayConnection.sendHelo connection
-        PCPRelayConnection.recvAtom connection
+        RelayClientConnection.sendHelo connection
+        RelayClientConnection.recvAtom connection
         |> Assert.ExpectAtomName Atom.PCP_OLEH
-        PCPRelayConnection.recvAtom connection
+        RelayClientConnection.recvAtom connection
         |> Assert.ExpectAtomName Atom.PCP_OK
         let os = waitForOutputStream channel
         os.OnStopped(stopReason)
@@ -272,12 +318,12 @@ module RelayTests =
         channel.ChannelInfo <- createChannelInfo "hoge" "FLV"
         channel.Start(null)
         peca.AddChannel channel
-        use connection = PCPRelayConnection.connect endpoint (channel.ChannelID)
+        use connection = RelayClientConnection.connect endpoint (channel.ChannelID)
         Assert.Equal(200, connection.response.status)
-        PCPRelayConnection.sendHelo connection
-        PCPRelayConnection.recvAtom connection
+        RelayClientConnection.sendHelo connection
+        RelayClientConnection.recvAtom connection
         |> Assert.ExpectAtomName Atom.PCP_OLEH
-        PCPRelayConnection.recvAtom connection
+        RelayClientConnection.recvAtom connection
         |> Assert.ExpectAtomName Atom.PCP_OK
         let createHostInfo i =
             let host = AtomCollection()
@@ -300,7 +346,7 @@ module RelayTests =
             PCPVersion.SetBcstVersion(bcst)
             bcst.SetBcstChannelID(channel.ChannelID)
             bcst.Add(host)
-            PCPRelayConnection.sendAtom (Atom(Atom.PCP_BCST, bcst)) connection
+            RelayClientConnection.sendAtom (Atom(Atom.PCP_BCST, bcst)) connection
         Seq.init 32 createHostInfo
         |> Seq.iter sendBcst
         Threading.Thread.Sleep(1000)
@@ -380,4 +426,153 @@ module RelayTests =
         Threading.Thread.Sleep(1000)
         expectRelay200 channel StopReason.UserShutdown |> ignore
         Assert.False(channel.HasBanned("127.0.0.1"))
+
+type RelayServerConnection =
+    {
+        endpoint : IPEndPoint;
+        channelId : Guid;
+        connection : System.Net.Sockets.TcpClient;
+        request: HTTPClient.Request;
+        localEndpoint : IPEndPoint;
+    }
+    interface IDisposable with
+        member this.Dispose() =
+            this.connection.Dispose()
+
+module RelayServerConnection =
+    let (|ParseChannelPath|_|) str =
+        let md = System.Text.RegularExpressions.Regex(@"^/channel/([A-Fa-f0-9]{32})[./?]?").Match(str)
+        if md.Success then
+            Some (Guid.Parse(md.Groups.[1].Value.Trim()))
+        else
+            None
+        
+    let listen endpoint =
+        async {
+            let! client = HTTPClient.listen endpoint
+            match HTTPClient.recvRequest client with
+            | Ok req ->
+                match req.pathAndQuery with
+                | ParseChannelPath channelId ->
+                    return Ok {
+                        endpoint = client.Client.RemoteEndPoint :?> IPEndPoint
+                        channelId = channelId
+                        connection = client
+                        request = req
+                        localEndpoint = endpoint
+                    }
+                | _ ->
+                    HTTPClient.sendResponse HttpStatusCode.NotFound Map.empty client
+                    return Error "No channel requested"
+            | Error err ->
+                return Error "No channel requested"
+        }
+
+    let sendResponse status connection =
+        HTTPClient.sendResponse status Map.empty connection.connection
+
+    let recvAtom connection =
+        connection.request.stream.ReadAtom()
+
+    let sendAtom value connection =
+        connection.request.stream.Write(value)
+
+module RelaySourceTests =
+    let endpoint = allocateEndPoint IPAddress.Loopback
+
+    let expectHelo connection =
+        let helo = RelayServerConnection.recvAtom connection
+        Assert.ExpectAtomName Atom.PCP_HELO helo
+        Assert.NotNull(helo.Children.GetHeloSessionID())
+        Assert.NotNull(helo.Children.GetHeloAgent())
+        Assert.NotNull(helo.Children.GetHeloVersion())
+
+    let sendOleh sessionId connection =
+        let oleh = AtomCollection()
+        oleh.SetHeloSessionID(sessionId)
+        RelayServerConnection.sendAtom (Atom(Atom.PCP_OLEH, oleh)) connection
+
+    let sendChanInfo (chanInfo:ChannelInfo) connection =
+        let chan = AtomCollection()
+        chan.SetChanInfo(chanInfo.Extra)
+        RelayServerConnection.sendAtom (Atom(Atom.PCP_CHAN, chan)) connection
+
+    let sendQuit connection =
+        RelayServerConnection.sendAtom (Atom(Atom.PCP_QUIT, Atom.PCP_ERROR_QUIT)) connection
+
+    [<Fact>]
+    let ``普通に接続したらデータ受信を開始する`` () =
+        use peca = new PeerCast()
+        let factory = new PCPSourceStreamFactory(peca)
+        Assert.True(factory.PCPHandshakeTimeout > 15000)
+        peca.SourceStreamFactories.Add(factory)
+        let sessionId = Guid.NewGuid()
+        let channelId = Guid.NewGuid()
+        let channel = RelayChannel(peca, NetworkType.IPv4, channelId)
+        let client = RelayServerConnection.listen endpoint
+        channel.Start(sprintf "pcp://%s:%d/channel/%s" (endpoint.Address.ToString()) endpoint.Port (channelId.ToString("N")) |> Uri)
+        peca.AddChannel channel
+        match Async.RunSynchronously client with
+        | Ok conn ->
+            use conn = conn
+            Assert.Equal(channelId, conn.channelId)
+            RelayServerConnection.sendResponse HttpStatusCode.OK conn
+            expectHelo conn
+            sendOleh sessionId conn
+            sendChanInfo (createChannelInfo "hoge" "FLV") conn
+            Threading.Thread.Sleep(1000)
+            Assert.Equal("hoge", channel.ChannelInfo.Name)
+            Assert.Equal("FLV", channel.ChannelInfo.ContentType)
+            sendQuit conn
+        | Error err ->
+            failwith err
+
+    [<Fact>]
+    let ``一定時間内にレスポンスを返さないとタイムアウトして接続を切る`` () =
+        use peca = new PeerCast()
+        let factory = new PCPSourceStreamFactory(peca)
+        factory.PCPHandshakeTimeout <- 2000
+        peca.SourceStreamFactories.Add(factory)
+        let channelId = Guid.NewGuid()
+        let channel = RelayChannel(peca, NetworkType.IPv4, channelId)
+        let client = RelayServerConnection.listen endpoint
+        channel.Start(sprintf "pcp://%s:%d/channel/%s" (endpoint.Address.ToString()) endpoint.Port (channelId.ToString("N")) |> Uri)
+        peca.AddChannel channel
+        match Async.RunSynchronously client with
+        | Ok conn ->
+            use conn = conn
+            Assert.Equal(channelId, conn.channelId)
+            Threading.Thread.Sleep(3000)
+            RelayServerConnection.sendResponse HttpStatusCode.OK conn
+            Assert.ThrowsAny<System.IO.IOException>(fun () ->
+                RelayServerConnection.recvAtom conn |> ignore
+            )
+        | Error err ->
+            failwith err
+
+    [<Fact>]
+    let ``一定時間内にOLEHを返さないとタイムアウトして接続を切る`` () =
+        use peca = new PeerCast()
+        let factory = new PCPSourceStreamFactory(peca)
+        factory.PCPHandshakeTimeout <- 2000
+        peca.SourceStreamFactories.Add(factory)
+        let sessionId = Guid.NewGuid()
+        let channelId = Guid.NewGuid()
+        let channel = RelayChannel(peca, NetworkType.IPv4, channelId)
+        let client = RelayServerConnection.listen endpoint
+        channel.Start(sprintf "pcp://%s:%d/channel/%s" (endpoint.Address.ToString()) endpoint.Port (channelId.ToString("N")) |> Uri)
+        peca.AddChannel channel
+        match Async.RunSynchronously client with
+        | Ok conn ->
+            use conn = conn
+            Assert.Equal(channelId, conn.channelId)
+            RelayServerConnection.sendResponse HttpStatusCode.OK conn
+            expectHelo conn
+            Threading.Thread.Sleep(3000)
+            sendOleh sessionId conn
+            Assert.ThrowsAny<System.IO.IOException>(fun () ->
+                RelayServerConnection.recvAtom conn |> ignore
+            )
+        | Error err ->
+            failwith err
 


### PR DESCRIPTION
PCPSourceStreamでリレー要求した時に、ハンドシェイクまでがいつまでも正常終了しない場合にはタイムアウト終了するようにした。
PeerCastでのポート開放確認に最大15秒かかるので、今のところ18秒でタイムアウトとしてある。