### PR TITLE
リレー受信がたまに固まって操作が受け付けられなくなるのを修正した

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/SourceConnectionBase.cs
+++ b/PeerCastStation/PeerCastStation.Core/SourceConnectionBase.cs
@@ -148,11 +148,16 @@ namespace PeerCastStation.Core
     public virtual void Stop(StopReason reason)
     {
       if (reason==StopReason.None) throw new ArgumentException("Invalid value", "reason");
-      if (reason==StopReason.UserShutdown && StoppedReason!=reason) StoppedReason = reason;
-      if (IsStopped) return;
-      StoppedReason = reason;
-      Logger.Debug($"Stop requested by reason {StoppedReason}");
-      isStopped.Cancel();
+      if (StoppedReason!=StopReason.UserShutdown) {
+        StoppedReason = reason;
+      }
+      if (IsStopped) {
+        Logger.Debug($"Stop requested by reason {reason} but already stopped");
+      }
+      else {
+        isStopped.Cancel();
+        Logger.Debug($"Stop requested by reason {reason}");
+      }
     }
 
     protected abstract Task<SourceConnectionClient> DoConnect(Uri source, CancellationToken cancellationToken);


### PR DESCRIPTION
リレー受信がたまに固まった状態になり、再接続や切断の操作すらも受け付けなくなることがあったので修正をした。

ConnectionStream で受信データが無い時に切断処理を行っても受信がキャンセルされなかったのでキャンセルされるようにした。