### PR TITLE
アップデート時にプラットフォーム毎のアーカイブを配布・ダウンロードできるようにする

### DIFF
--- a/PeerCastStation/PecaStationd/PecaStationd.csproj
+++ b/PeerCastStation/PecaStationd/PecaStationd.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>WinExe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/PeerCastStation/PecaStationdDebug/PecaStationdDebug.csproj
+++ b/PeerCastStation/PecaStationdDebug/PecaStationdDebug.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/PeerCastStation/PeerCastStation.ASF/PeerCastStation.ASF.csproj
+++ b/PeerCastStation/PeerCastStation.ASF/PeerCastStation.ASF.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>Library</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\PeerCastStation\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/PeerCastStation/PeerCastStation.App/PeerCastStation.App.csproj
+++ b/PeerCastStation/PeerCastStation.App/PeerCastStation.App.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/PeerCastStation/PeerCastStation.Core/PeerCastStation.Core.csproj
+++ b/PeerCastStation/PeerCastStation.Core/PeerCastStation.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>Library</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\PeerCastStation\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/PeerCastStation/PeerCastStation.CustomFilter/PeerCastStation.CustomFilter.csproj
+++ b/PeerCastStation/PeerCastStation.CustomFilter/PeerCastStation.CustomFilter.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/PeerCastStation/PeerCastStation.FLV/PeerCastStation.FLV.csproj
+++ b/PeerCastStation/PeerCastStation.FLV/PeerCastStation.FLV.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>Library</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\PeerCastStation\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/PeerCastStation/PeerCastStation.HTTP/PeerCastStation.HTTP.csproj
+++ b/PeerCastStation/PeerCastStation.HTTP/PeerCastStation.HTTP.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>Library</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\PeerCastStation\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/PeerCastStation/PeerCastStation.MKV/PeerCastStation.MKV.csproj
+++ b/PeerCastStation/PeerCastStation.MKV/PeerCastStation.MKV.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>Library</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\PeerCastStation\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/PeerCastStation/PeerCastStation.PCP/PeerCastStation.PCP.csproj
+++ b/PeerCastStation/PeerCastStation.PCP/PeerCastStation.PCP.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>Library</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\PeerCastStation\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/PeerCastStation/PeerCastStation.TS/PeerCastStation.TS.csproj
+++ b/PeerCastStation/PeerCastStation.TS/PeerCastStation.TS.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/PeerCastStation/PeerCastStation.Test/PeerCastStation.Test.fsproj
+++ b/PeerCastStation/PeerCastStation.Test/PeerCastStation.Test.fsproj
@@ -42,6 +42,7 @@
     <Compile Include="HttpTests.fs" />
     <Compile Include="Tests.fs" />
     <Compile Include="PCPTests.fs" />
+    <Compile Include="UpdaterTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/PeerCastStation/PeerCastStation.Test/UpdaterTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/UpdaterTests.fs
@@ -1,0 +1,324 @@
+﻿module UpdaterTests
+
+open Xunit
+open System
+open PeerCastStation.UI
+open TestCommon
+
+let enclosuresAll = [|
+    VersionEnclosure(
+        Title="hoge",
+        Length=12345L,
+        Type="application/octet-stream",
+        Url=Uri "http://example.com/files/hoge-windows-x86.zip",
+        InstallerType=InstallerType.Archive,
+        InstallerPlatform=InstallerPlatform.Unknown)
+    VersionEnclosure(
+        Title="hoge",
+        Length=12345L,
+        Type="application/octet-stream",
+        Url=Uri "http://example.com/files/hoge-windows-x86.exe",
+        InstallerType=InstallerType.Installer,
+        InstallerPlatform=InstallerPlatform.Unknown)
+    VersionEnclosure(
+        Title="hoge",
+        Length=12345L,
+        Type="application/octet-stream",
+        Url=Uri "http://example.com/files/hoge-windows-x86.msi",
+        InstallerType=InstallerType.ServiceInstaller,
+        InstallerPlatform=InstallerPlatform.Unknown)
+    VersionEnclosure(
+        Title="hoge",
+        Length=12345L,
+        Type="application/octet-stream",
+        Url=Uri "http://example.com/files/hoge-any.zip",
+        InstallerType=InstallerType.Archive,
+        InstallerPlatform=InstallerPlatform.Any)
+    VersionEnclosure(
+        Title="hoge",
+        Length=12345L,
+        Type="application/octet-stream",
+        Url=Uri "http://example.com/files/hoge-windows-x64.zip",
+        InstallerType=InstallerType.Archive,
+        InstallerPlatform=InstallerPlatform.WindowsX64)
+    VersionEnclosure(
+        Title="hoge",
+        Length=12345L,
+        Type="application/octet-stream",
+        Url=Uri "http://example.com/files/hoge-windows-x64.exe",
+        InstallerType=InstallerType.Installer,
+        InstallerPlatform=InstallerPlatform.WindowsX64)
+    VersionEnclosure(
+        Title="hoge",
+        Length=12345L,
+        Type="application/octet-stream",
+        Url=Uri "http://example.com/files/hoge-windows-x64.msi",
+        InstallerType=InstallerType.ServiceInstaller,
+        InstallerPlatform=InstallerPlatform.WindowsX64)
+    VersionEnclosure(
+        Title="hoge",
+        Length=12345L,
+        Type="application/octet-stream",
+        Url=Uri "http://example.com/files/hoge-windows-x86.zip",
+        InstallerType=InstallerType.Archive,
+        InstallerPlatform=InstallerPlatform.WindowsX86)
+    VersionEnclosure(
+        Title="hoge",
+        Length=12345L,
+        Type="application/octet-stream",
+        Url=Uri "http://example.com/files/hoge-windows-x86.zip",
+        InstallerType=InstallerType.Archive,
+        InstallerPlatform=InstallerPlatform.WindowsX86)
+    VersionEnclosure(
+        Title="hoge",
+        Length=12345L,
+        Type="application/octet-stream",
+        Url=Uri "http://example.com/files/hoge-windows-x86.exe",
+        InstallerType=InstallerType.Installer,
+        InstallerPlatform=InstallerPlatform.WindowsX86)
+    VersionEnclosure(
+        Title="hoge",
+        Length=12345L,
+        Type="application/octet-stream",
+        Url=Uri "http://example.com/files/hoge-windows-x86.msi",
+        InstallerType=InstallerType.ServiceInstaller,
+        InstallerPlatform=InstallerPlatform.WindowsX86)
+    VersionEnclosure(
+        Title="hoge",
+        Length=12345L,
+        Type="application/octet-stream",
+        Url=Uri "http://example.com/files/hoge-linux-x64.zip",
+        InstallerType=InstallerType.Archive,
+        InstallerPlatform=InstallerPlatform.LinuxX64)
+    VersionEnclosure(
+        Title="hoge",
+        Length=12345L,
+        Type="application/octet-stream",
+        Url=Uri "http://example.com/files/hoge-linux-musl-x64.zip",
+        InstallerType=InstallerType.Archive,
+        InstallerPlatform=InstallerPlatform.LinuxMuslX64)
+    VersionEnclosure(
+        Title="hoge",
+        Length=12345L,
+        Type="application/octet-stream",
+        Url=Uri "http://example.com/files/hoge-linux-arm.zip",
+        InstallerType=InstallerType.Archive,
+        InstallerPlatform=InstallerPlatform.LinuxArm)
+    VersionEnclosure(
+        Title="hoge",
+        Length=12345L,
+        Type="application/octet-stream",
+        Url=Uri "http://example.com/files/hoge-linux-musl-arm.zip",
+        InstallerType=InstallerType.Archive,
+        InstallerPlatform=InstallerPlatform.LinuxMuslArm)
+    VersionEnclosure(
+        Title="hoge",
+        Length=12345L,
+        Type="application/octet-stream",
+        Url=Uri "http://example.com/files/hoge-linux-arm64.zip",
+        InstallerType=InstallerType.Archive,
+        InstallerPlatform=InstallerPlatform.LinuxArm64)
+    VersionEnclosure(
+        Title="hoge",
+        Length=12345L,
+        Type="application/octet-stream",
+        Url=Uri "http://example.com/files/hoge-linux-musl-arm64.zip",
+        InstallerType=InstallerType.Archive,
+        InstallerPlatform=InstallerPlatform.LinuxMuslArm64)
+|]
+
+let enclosuresMin = [|
+    VersionEnclosure(
+        Title="hoge",
+        Length=12345L,
+        Type="application/octet-stream",
+        Url=Uri "http://example.com/files/hoge-any.zip",
+        InstallerType=InstallerType.Archive,
+        InstallerPlatform=InstallerPlatform.Unknown)
+    VersionEnclosure(
+        Title="hoge",
+        Length=12345L,
+        Type="application/octet-stream",
+        Url=Uri "http://example.com/files/hoge-any.exe",
+        InstallerType=InstallerType.Installer,
+        InstallerPlatform=InstallerPlatform.Unknown)
+    VersionEnclosure(
+        Title="hoge",
+        Length=12345L,
+        Type="application/octet-stream",
+        Url=Uri "http://example.com/files/hoge-any.msi",
+        InstallerType=InstallerType.ServiceInstaller,
+        InstallerPlatform=InstallerPlatform.Unknown)
+|]
+
+[<Fact>]
+let ``インストールタイプとプラットフォームから適切なファイルを選択できる`` () =
+    [
+        ((InstallerType.Archive, InstallerPlatform.Unknown), (InstallerType.Archive, InstallerPlatform.Unknown))
+        ((InstallerType.Archive, InstallerPlatform.Any), (InstallerType.Archive, InstallerPlatform.Any))
+        ((InstallerType.Archive, InstallerPlatform.WindowsX86), (InstallerType.Archive, InstallerPlatform.WindowsX86))
+        ((InstallerType.Archive, InstallerPlatform.WindowsX64), (InstallerType.Archive, InstallerPlatform.WindowsX64))
+        ((InstallerType.Archive, InstallerPlatform.WindowsArm), (InstallerType.Archive, InstallerPlatform.WindowsX86))
+        ((InstallerType.Archive, InstallerPlatform.WindowsArm64), (InstallerType.Archive, InstallerPlatform.WindowsX86))
+        ((InstallerType.Installer, InstallerPlatform.WindowsX86), (InstallerType.Installer, InstallerPlatform.WindowsX86))
+        ((InstallerType.Installer, InstallerPlatform.WindowsX64), (InstallerType.Installer, InstallerPlatform.WindowsX64))
+        ((InstallerType.Installer, InstallerPlatform.WindowsArm), (InstallerType.Installer, InstallerPlatform.WindowsX86))
+        ((InstallerType.Installer, InstallerPlatform.WindowsArm64), (InstallerType.Installer, InstallerPlatform.WindowsX86))
+        ((InstallerType.ServiceInstaller, InstallerPlatform.WindowsX86), (InstallerType.ServiceInstaller, InstallerPlatform.WindowsX86))
+        ((InstallerType.ServiceInstaller, InstallerPlatform.WindowsX64), (InstallerType.ServiceInstaller, InstallerPlatform.WindowsX64))
+        ((InstallerType.ServiceInstaller, InstallerPlatform.WindowsArm), (InstallerType.ServiceInstaller, InstallerPlatform.WindowsX86))
+        ((InstallerType.ServiceInstaller, InstallerPlatform.WindowsArm64), (InstallerType.ServiceInstaller, InstallerPlatform.WindowsX86))
+        ((InstallerType.Archive, InstallerPlatform.LinuxX64), (InstallerType.Archive, InstallerPlatform.LinuxX64))
+        ((InstallerType.Archive, InstallerPlatform.LinuxMuslX64), (InstallerType.Archive, InstallerPlatform.LinuxMuslX64))
+        ((InstallerType.Archive, InstallerPlatform.LinuxArm), (InstallerType.Archive, InstallerPlatform.LinuxArm))
+        ((InstallerType.Archive, InstallerPlatform.LinuxMuslArm), (InstallerType.Archive, InstallerPlatform.LinuxMuslArm))
+        ((InstallerType.Archive, InstallerPlatform.LinuxArm64), (InstallerType.Archive, InstallerPlatform.LinuxArm64))
+        ((InstallerType.Archive, InstallerPlatform.LinuxMuslArm64), (InstallerType.Archive, InstallerPlatform.LinuxMuslArm64))
+        ((InstallerType.Archive, InstallerPlatform.MacX64), (InstallerType.Archive, InstallerPlatform.Any))
+        ((InstallerType.Archive, InstallerPlatform.MacArm64), (InstallerType.Archive, InstallerPlatform.Any))
+    ]
+    |> List.iter (fun ((specifiedType, specifiedPlatform), (expectedType, expectedPlatform)) ->
+        let enclosure = Updater.SelectEnclosure(enclosuresAll, specifiedType, specifiedPlatform)
+        Assert.Equal(expectedType, enclosure.InstallerType)
+        Assert.Equal(expectedPlatform, enclosure.InstallerPlatform)
+    )
+    [
+        ((InstallerType.Archive, InstallerPlatform.Unknown), (InstallerType.Archive, InstallerPlatform.Unknown))
+        ((InstallerType.Archive, InstallerPlatform.Any), (InstallerType.Archive, InstallerPlatform.Unknown))
+        ((InstallerType.Archive, InstallerPlatform.WindowsX86), (InstallerType.Archive, InstallerPlatform.Unknown))
+        ((InstallerType.Archive, InstallerPlatform.WindowsX64), (InstallerType.Archive, InstallerPlatform.Unknown))
+        ((InstallerType.Archive, InstallerPlatform.WindowsArm), (InstallerType.Archive, InstallerPlatform.Unknown))
+        ((InstallerType.Archive, InstallerPlatform.WindowsArm64), (InstallerType.Archive, InstallerPlatform.Unknown))
+        ((InstallerType.Installer, InstallerPlatform.WindowsX86), (InstallerType.Installer, InstallerPlatform.Unknown))
+        ((InstallerType.Installer, InstallerPlatform.WindowsX64), (InstallerType.Installer, InstallerPlatform.Unknown))
+        ((InstallerType.Installer, InstallerPlatform.WindowsArm), (InstallerType.Installer, InstallerPlatform.Unknown))
+        ((InstallerType.Installer, InstallerPlatform.WindowsArm64), (InstallerType.Installer, InstallerPlatform.Unknown))
+        ((InstallerType.ServiceInstaller, InstallerPlatform.WindowsX86), (InstallerType.ServiceInstaller, InstallerPlatform.Unknown))
+        ((InstallerType.ServiceInstaller, InstallerPlatform.WindowsX64), (InstallerType.ServiceInstaller, InstallerPlatform.Unknown))
+        ((InstallerType.ServiceInstaller, InstallerPlatform.WindowsArm), (InstallerType.ServiceInstaller, InstallerPlatform.Unknown))
+        ((InstallerType.ServiceInstaller, InstallerPlatform.WindowsArm64), (InstallerType.ServiceInstaller, InstallerPlatform.Unknown))
+        ((InstallerType.Archive, InstallerPlatform.LinuxX64), (InstallerType.Archive, InstallerPlatform.Unknown))
+        ((InstallerType.Archive, InstallerPlatform.LinuxMuslX64), (InstallerType.Archive, InstallerPlatform.Unknown))
+        ((InstallerType.Archive, InstallerPlatform.LinuxArm), (InstallerType.Archive, InstallerPlatform.Unknown))
+        ((InstallerType.Archive, InstallerPlatform.LinuxMuslArm), (InstallerType.Archive, InstallerPlatform.Unknown))
+        ((InstallerType.Archive, InstallerPlatform.LinuxArm64), (InstallerType.Archive, InstallerPlatform.Unknown))
+        ((InstallerType.Archive, InstallerPlatform.LinuxMuslArm64), (InstallerType.Archive, InstallerPlatform.Unknown))
+        ((InstallerType.Archive, InstallerPlatform.MacX64), (InstallerType.Archive, InstallerPlatform.Unknown))
+        ((InstallerType.Archive, InstallerPlatform.MacArm64), (InstallerType.Archive, InstallerPlatform.Unknown))
+    ]
+    |> List.iter (fun ((specifiedType, specifiedPlatform), (expectedType, expectedPlatform)) ->
+        let enclosure = Updater.SelectEnclosure(enclosuresMin, specifiedType, specifiedPlatform)
+        Assert.Equal(expectedType, enclosure.InstallerType)
+        Assert.Equal(expectedPlatform, enclosure.InstallerPlatform)
+    )
+
+[<Fact>]
+let ``プラットフォーム指定の文字列をパースできる`` () =
+    [
+      ("any", InstallerPlatform.Any)
+      ("win-x86", InstallerPlatform.WindowsX86)
+      ("win-x64", InstallerPlatform.WindowsX64)
+      ("win-arm", InstallerPlatform.WindowsArm)
+      ("win-arm64", InstallerPlatform.WindowsArm64)
+      ("linux-x64", InstallerPlatform.LinuxX64)
+      ("linux-musl-x64", InstallerPlatform.LinuxMuslX64)
+      ("linux-arm", InstallerPlatform.LinuxArm)
+      ("linux-musl-arm", InstallerPlatform.LinuxMuslArm)
+      ("linux-arm64", InstallerPlatform.LinuxArm64)
+      ("linux-musl-arm64", InstallerPlatform.LinuxMuslArm64)
+      ("osx-x64", InstallerPlatform.MacX64)
+      ("osx-arm64", InstallerPlatform.MacArm64)
+      ("unknown", InstallerPlatform.Unknown)
+      ("ANY", InstallerPlatform.Any)
+      ("WIN-X86", InstallerPlatform.WindowsX86)
+      ("WIN-X64", InstallerPlatform.WindowsX64)
+      ("WIN-ARM", InstallerPlatform.WindowsArm)
+      ("WIN-ARM64", InstallerPlatform.WindowsArm64)
+      ("LINUX-X64", InstallerPlatform.LinuxX64)
+      ("LINUX-MUSL-X64", InstallerPlatform.LinuxMuslX64)
+      ("LINUX-ARM", InstallerPlatform.LinuxArm)
+      ("LINUX-MUSL-ARM", InstallerPlatform.LinuxMuslArm)
+      ("LINUX-ARM64", InstallerPlatform.LinuxArm64)
+      ("LINUX-MUSL-ARM64", InstallerPlatform.LinuxMuslArm64)
+      ("OSX-X64", InstallerPlatform.MacX64)
+      ("OSX-ARM64", InstallerPlatform.MacArm64)
+      ("UNKNOWN", InstallerPlatform.Unknown)
+      ("hoge", InstallerPlatform.Unknown)
+    ]
+    |> List.iter (fun (specifiedStr, expectedPlatform) ->
+        Assert.Equal(expectedPlatform, Updater.ParsePlatformString(specifiedStr))
+    )
+
+let appCast = """<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>PeerCastStation更新情報</title>
+    <link>http://www.pecastation.org/</link>
+    <description>PeerCastStationの更新情報です</description>
+    <language>ja</language>
+    <item>
+      <title>Version 2.5.1.209 (Test Only)</title>
+      <description>
+          <h1>Version 2.5.1.209 (Test Only)</h1>
+          <p>テスト用です。見なかったことにしてください。</p>
+      </description>
+      <pubDate>Mon, 28 May 2018 01:00:00 +0900</pubDate>
+      <link>http://example.com/files/hoge-windows-x86.zip</link>
+      <enclosure installer-type="archive" url="http://example.com/files/hoge-windows-x86.zip" length="123456" type="application/octet-stream" />
+      <enclosure installer-type="installer" url="http://example.com/files/hoge-windows-x86.exe" length="2341639" type="application/octet-stream" />
+      <enclosure installer-type="serviceinstaller" url="http://example.com/files/hoge-windows-x86.msi" length="2024226" type="application/octet-stream" />
+      <enclosure installer-type="archive" installer-platform="any" url="http://example.com/files/hoge-any.zip" length="123456" type="application/octet-stream" />
+      <enclosure installer-type="archive" installer-platform="win-x86" url="http://example.com/files/hoge-windows-x86.zip" length="123456" type="application/octet-stream" />
+      <enclosure installer-type="installer" installer-platform="win-x86" url="http://example.com/files/hoge-windows-x86.exe" length="2341639" type="application/octet-stream" />
+      <enclosure installer-type="serviceinstaller" installer-platform="win-x86" url="http://example.com/files/hoge-windows-x86.msi" length="2024226" type="application/octet-stream" />
+      <enclosure installer-type="archive" installer-platform="win-x64" url="http://example.com/files/hoge-windows-x64.zip" length="123456" type="application/octet-stream" />
+      <enclosure installer-type="installer" installer-platform="win-x64" url="http://example.com/files/hoge-windows-x64.exe" length="2341639" type="application/octet-stream" />
+      <enclosure installer-type="serviceinstaller" installer-platform="win-x64" url="http://example.com/files/hoge-windows-x64.msi" length="2024226" type="application/octet-stream" />
+      <enclosure installer-type="archive" installer-platform="linux-x64" url="http://example.com/files/hoge-linux-x64.zip" length="123456" type="application/octet-stream" />
+      <enclosure installer-type="archive" installer-platform="linux-arm" url="http://example.com/files/hoge-linux-arm.zip" length="123456" type="application/octet-stream" />
+      <enclosure installer-type="archive" installer-platform="linux-arm64" url="http://example.com/files/hoge-linux-arm64.zip" length="123456" type="application/octet-stream" />
+      <enclosure installer-type="archive" installer-platform="linux-musl-x64" url="http://example.com/files/hoge-linux-musl-x64.zip" length="123456" type="application/octet-stream" />
+      <enclosure installer-type="archive" installer-platform="linux-musl-arm" url="http://example.com/files/hoge-linux-musl-arm.zip" length="123456" type="application/octet-stream" />
+      <enclosure installer-type="archive" installer-platform="linux-musl-arm64" url="http://example.com/files/hoge-linux-musl-arm64.zip" length="123456" type="application/octet-stream" />
+    </item>
+  </channel>
+</rss>
+"""
+
+[<Fact>]
+let ``AppCastでプラットフォーム毎のEnclosureが取得できる`` () =
+    let reader = AppCastReader()
+    let versionDesciptions = reader.ParseAppCastString(appCast)
+    Assert.Equal(1, Seq.length versionDesciptions)
+    let ver = Seq.head versionDesciptions
+    [
+        (InstallerType.Archive, InstallerPlatform.Unknown, true)
+        (InstallerType.Archive, InstallerPlatform.Any, true)
+        (InstallerType.Archive, InstallerPlatform.WindowsX86, true)
+        (InstallerType.Archive, InstallerPlatform.WindowsX64, true)
+        (InstallerType.Archive, InstallerPlatform.WindowsArm, false)
+        (InstallerType.Archive, InstallerPlatform.WindowsArm64, false)
+        (InstallerType.Installer, InstallerPlatform.WindowsX86, true)
+        (InstallerType.Installer, InstallerPlatform.WindowsX64, true)
+        (InstallerType.Installer, InstallerPlatform.WindowsArm, false)
+        (InstallerType.Installer, InstallerPlatform.WindowsArm64, false)
+        (InstallerType.ServiceInstaller, InstallerPlatform.WindowsX86, true)
+        (InstallerType.ServiceInstaller, InstallerPlatform.WindowsX64, true)
+        (InstallerType.ServiceInstaller, InstallerPlatform.WindowsArm, false)
+        (InstallerType.ServiceInstaller, InstallerPlatform.WindowsArm64, false)
+        (InstallerType.Archive, InstallerPlatform.LinuxX64, true)
+        (InstallerType.Archive, InstallerPlatform.LinuxMuslX64, true)
+        (InstallerType.Archive, InstallerPlatform.LinuxArm, true)
+        (InstallerType.Archive, InstallerPlatform.LinuxMuslArm, true)
+        (InstallerType.Archive, InstallerPlatform.LinuxArm64, true)
+        (InstallerType.Archive, InstallerPlatform.LinuxMuslArm64, true)
+        (InstallerType.Archive, InstallerPlatform.MacX64, false)
+        (InstallerType.Archive, InstallerPlatform.MacArm64, false)
+    ]
+    |> List.iter (fun (itype, iplatform, exists) ->
+        Assert.Equal(exists,
+            ver.Enclosures
+            |> Seq.exists (fun enc -> enc.InstallerPlatform = iplatform && enc.InstallerType = itype)
+        )
+    )
+

--- a/PeerCastStation/PeerCastStation.UI.HTTP/PeerCastStation.UI.HTTP.csproj
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/PeerCastStation.UI.HTTP.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>Library</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\PeerCastStation\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/PeerCastStation/PeerCastStation.UI/AppCastReader.cs
+++ b/PeerCastStation/PeerCastStation.UI/AppCastReader.cs
@@ -69,6 +69,11 @@ namespace PeerCastStation.UI
       return result;
     }
 
+    private InstallerPlatform GetInstallerPlatformValue(XAttribute src)
+    {
+      return Updater.ParsePlatformString(src?.Value ?? "unknown");
+    }
+
     private Uri GetUriValue(XElement src)
     {
       Uri result = null;
@@ -123,6 +128,7 @@ namespace PeerCastStation.UI
                 Type   = GetStringValue(elt.Attribute("type")),
                 Title  = GetStringValue(elt),
                 InstallerType = GetInstallerTypeValue(elt.Attribute("installer-type")),
+                InstallerPlatform = GetInstallerPlatformValue(elt.Attribute("installer-platform")),
               }
             ).ToArray(),
           };

--- a/PeerCastStation/PeerCastStation.UI/PeerCastStation.UI.csproj
+++ b/PeerCastStation/PeerCastStation.UI/PeerCastStation.UI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>Library</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/PeerCastStation/PeerCastStation.UI/Updater.cs
+++ b/PeerCastStation/PeerCastStation.UI/Updater.cs
@@ -27,10 +27,13 @@ namespace PeerCastStation.UI
     WindowsArm,
     WindowsArm64,
     LinuxX64,
-    LinuxMUSLX64,
+    LinuxMuslX64,
     LinuxArm,
+    LinuxMuslArm,
     LinuxArm64,
+    LinuxMuslArm64,
     MacX64,
+    MacArm64,
   }
 
   public class VersionEnclosure
@@ -88,24 +91,30 @@ namespace PeerCastStation.UI
       switch (value.ToLowerInvariant()) {
       case "any":
         return InstallerPlatform.Any;
-      case "windows-x86":
+      case "win-x86":
         return InstallerPlatform.WindowsX86;
-      case "windows-x64":
+      case "win-x64":
         return InstallerPlatform.WindowsX64;
-      case "windows-arm":
+      case "win-arm":
         return InstallerPlatform.WindowsArm;
-      case "windows-arm64":
+      case "win-arm64":
         return InstallerPlatform.WindowsArm64;
       case "linux-x64":
         return InstallerPlatform.LinuxX64;
       case "linux-musl-x64":
-        return InstallerPlatform.LinuxMUSLX64;
+        return InstallerPlatform.LinuxMuslX64;
       case "linux-arm":
         return InstallerPlatform.LinuxArm;
+      case "linux-musl-arm":
+        return InstallerPlatform.LinuxMuslArm;
       case "linux-arm64":
         return InstallerPlatform.LinuxArm64;
+      case "linux-musl-arm64":
+        return InstallerPlatform.LinuxMuslArm64;
       case "osx-x64":
         return InstallerPlatform.MacX64;
+      case "osx-arm64":
+        return InstallerPlatform.MacArm64;
       case "unknown":
       default:
         return InstallerPlatform.Unknown;
@@ -147,8 +156,9 @@ namespace PeerCastStation.UI
             switch (RuntimeInformation.ProcessArchitecture) {
             case Architecture.X64:
               return InstallerPlatform.MacX64;
-            case Architecture.Arm:
             case Architecture.Arm64:
+              return InstallerPlatform.MacArm64;
+            case Architecture.Arm:
             case Architecture.X86:
             default:
               return InstallerPlatform.Unknown;
@@ -205,7 +215,7 @@ namespace PeerCastStation.UI
       }
     }
 
-    private static VersionEnclosure SelectEnclocure(VersionEnclosure[] enclosures, InstallerType type, InstallerPlatform platform)
+    public static VersionEnclosure SelectEnclosure(VersionEnclosure[] enclosures, InstallerType type, InstallerPlatform platform)
     {
       var enclosure = enclosures.FirstOrDefault(e => e.InstallerType==type && e.InstallerPlatform==platform);
       if (enclosure!=null) {
@@ -214,19 +224,19 @@ namespace PeerCastStation.UI
       switch (platform) {
       case InstallerPlatform.WindowsArm:
       case InstallerPlatform.WindowsArm64:
-        return SelectEnclocure(enclosures, type, InstallerPlatform.WindowsX86);
+        return SelectEnclosure(enclosures, type, InstallerPlatform.WindowsX86);
       case InstallerPlatform.Any:
-        return SelectEnclocure(enclosures, type, InstallerPlatform.Unknown);
+        return SelectEnclosure(enclosures, type, InstallerPlatform.Unknown);
       case InstallerPlatform.Unknown:
         return enclosures.First(e => e.InstallerType==type && e.InstallerPlatform==InstallerPlatform.Any);
       default:
-        return SelectEnclocure(enclosures, type, InstallerPlatform.Any);
+        return SelectEnclosure(enclosures, type, InstallerPlatform.Any);
       }
     }
 
     public static async Task<DownloadResult> DownloadAsync(VersionDescription version, Action<float> onprogress, CancellationToken ct)
     {
-      var enclosure = SelectEnclocure(version.Enclosures, CurrentInstallerType, CurrentInstallerPlatform);
+      var enclosure = SelectEnclosure(version.Enclosures, CurrentInstallerType, CurrentInstallerPlatform);
       using (var client = new System.Net.WebClient())
       using (ct.Register(() => client.CancelAsync(), false)) {
         if (onprogress!=null) {

--- a/PeerCastStation/PeerCastStation.WPF/PeerCastStation.WPF.csproj
+++ b/PeerCastStation/PeerCastStation.WPF/PeerCastStation.WPF.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>Library</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/PeerCastStation/PeerCastStation/PeerCastStation.cs
+++ b/PeerCastStation/PeerCastStation/PeerCastStation.cs
@@ -31,24 +31,22 @@ namespace PeerCastStation.Main
       return (int)result;
     }
 
-    static readonly int MaxRetries = 10;
-
     static int ProcessUpdate(string basepath, string sourcepath, string targetpath, string[] args)
     {
-      global::PeerCastStation.UI.Updater.Update(sourcepath, targetpath);
-      global::PeerCastStation.UI.Updater.StartCleanup(targetpath, sourcepath, args);
+      UI.Updater.Update(sourcepath, targetpath);
+      UI.Updater.StartCleanup(targetpath, sourcepath, args);
       return 0;
     }
 
     static int ProcessInstall(string basepath, string zipfile, string[] args)
     {
-      global::PeerCastStation.UI.Updater.Install(zipfile);
+      UI.Updater.Install(zipfile);
       return 0;
     }
 
     static int ProcessCleanup(string basepath, string tmppath, string[] args)
     {
-      global::PeerCastStation.UI.Updater.Cleanup(tmppath);
+      UI.Updater.Cleanup(tmppath);
       return ProcessMain(basepath, args);
     }
 

--- a/PeerCastStation/PeerCastStation/PeerCastStation.csproj
+++ b/PeerCastStation/PeerCastStation/PeerCastStation.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <OutputType>WinExe</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\PeerCastStation\</SolutionDir>

--- a/PeerCastStation/PeerCastStation/app.config
+++ b/PeerCastStation/PeerCastStation/app.config
@@ -23,6 +23,7 @@
     <add key="UpdateURL" value="http://www.pecastation.org/files/appcast-dev.xml"/>
     <add key="CurrentVersion" value="2020-2-26"/>
     <add key="InstallerType" value="installer" />
+    <add key="InstallerPlatform" value="" />
     <add key="BandwidthChecker"   value="http://api.pecastation.org/bandwidth" />
     <add key="BandwidthCheckerV6" value="http://v6.api.pecastation.org/bandwidth" />
     <add key="PCPPortChecker"   value="http://api.pecastation.org/portcheck" />

--- a/PeerCastStation/SetupBundle/Bundle.wxs
+++ b/PeerCastStation/SetupBundle/Bundle.wxs
@@ -32,7 +32,7 @@
 				LicenseUrl="" />
 		</BootstrapperApplicationRef>
 		<Chain>
-			<PackageGroupRef Id="NetFx452Web"/>
+			<PackageGroupRef Id="NetFx462Web"/>
 			<MsiPackage Id="PeerCastStationInstaller" SourceFile="$(var.PeerCastStationInstaller.TargetPath)" Permanent="no">
 				<MsiProperty Name="INSTALLFOLDER" Value="[InstallFolder]"/>
 			</MsiPackage>


### PR DESCRIPTION
.NET以降だとプラットフォーム毎に別のアーカイブを配布する必要があるので、アップデート時にもなるべく現在のプラットフォームに合わせたアーカイブを配布・ダウンロードできるようにした。