### PR TITLE
GUIのタイトルバー文字列を設定で変えられるようにする

### DIFF
--- a/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingControl.xaml
+++ b/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingControl.xaml
@@ -538,17 +538,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. -->
               <RowDefinition Height="Auto"/>
               <RowDefinition Height="Auto"/>
               <RowDefinition Height="Auto"/>
+              <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
               <ColumnDefinition Width="Auto"/>
               <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
-            <CheckBox Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="0" Margin="2" Content="起動時にウィンドウを表示する" IsChecked="{Binding IsShowWindowOnStartup}"/>
-            <CheckBox Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="1" Margin="2" Content="通知を表示する" IsChecked="{Binding IsShowNotifications}"/>
-            <Label    Grid.Column="0" Grid.Row="2" Content="接続先表示:"/>
-            <ComboBox Grid.Column="1" Grid.Row="2" Margin="2" ItemsSource="{Binding RemoteNodeNameItems}" DisplayMemberPath="Name" SelectedValuePath="Value" IsEditable="False" SelectedValue="{Binding RemoteNodeName}"/>
-            <Label    Grid.Column="0" Grid.Row="3" Content="視聴方法:"/>
-            <Grid Grid.Column="1" Grid.Row="3">
+            <Label    Grid.Column="0" Grid.Row="0" Content="ウィンドウタイトル"/>
+            <ComboBox Grid.Column="1" Grid.Row="0" Margin="2" ItemsSource="{Binding WindowTitleModeNameItems}" DisplayMemberPath="Name" SelectedValuePath="Value" IsEditable="False" SelectedValue="{Binding WindowTitleMode}"/>
+            <CheckBox Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="1" Margin="2" Content="起動時にウィンドウを表示する" IsChecked="{Binding IsShowWindowOnStartup}"/>
+            <CheckBox Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="2" Margin="2" Content="通知を表示する" IsChecked="{Binding IsShowNotifications}"/>
+            <Label    Grid.Column="0" Grid.Row="3" Content="接続先表示:"/>
+            <ComboBox Grid.Column="1" Grid.Row="3" Margin="2" ItemsSource="{Binding RemoteNodeNameItems}" DisplayMemberPath="Name" SelectedValuePath="Value" IsEditable="False" SelectedValue="{Binding RemoteNodeName}"/>
+            <Label    Grid.Column="0" Grid.Row="4" Content="視聴方法:"/>
+            <Grid Grid.Column="1" Grid.Row="4">
               <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
               </Grid.RowDefinitions>

--- a/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingViewModel.cs
+++ b/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingViewModel.cs
@@ -912,6 +912,19 @@ namespace PeerCastStation.WPF.CoreSettings
       set { SetProperty("IsShowNotifications", ref isShowNotifications, value); }
     }
 
+    public IEnumerable<NamedValue<WindowTitleMode>> WindowTitleModeNameItems { get; } =
+      new NamedValueList<WindowTitleMode> {
+        { "シンプル", WindowTitleMode.Simple },
+        { "バージョン付き", WindowTitleMode.Version },
+        { "視聴/リレー数", WindowTitleMode.ChannelStats },
+      };
+
+    private WindowTitleMode windowTitleMode;
+    public WindowTitleMode WindowTitleMode {
+      get { return windowTitleMode; }
+      set { SetProperty(nameof(WindowTitleMode), ref windowTitleMode, value); }
+    }
+
     private static readonly NamedValueList<RemoteNodeName> remoteNodeNameItems =
       new NamedValueList<RemoteNodeName> {
         { "セッションID", RemoteNodeName.SessionID },
@@ -970,6 +983,7 @@ namespace PeerCastStation.WPF.CoreSettings
       isShowWindowOnStartup = pecaApp.Settings.Get<WPFSettings>().ShowWindowOnStartup;
       isShowNotifications   = pecaApp.Settings.Get<WPFSettings>().ShowNotifications;
       remoteNodeName        = pecaApp.Settings.Get<WPFSettings>().RemoteNodeName;
+      windowTitleMode        = pecaApp.Settings.Get<WPFSettings>().WindowTitleMode;
       ports = new ViewModelCollection<OutputListenerViewModel>(
         peerCast.OutputListeners
         .Select(listener => new OutputListenerViewModel(this, listener))
@@ -1198,6 +1212,7 @@ namespace PeerCastStation.WPF.CoreSettings
       pecaApp.Settings.Get<WPFSettings>().ShowWindowOnStartup = isShowWindowOnStartup;
       pecaApp.Settings.Get<WPFSettings>().ShowNotifications = isShowNotifications;
       pecaApp.Settings.Get<WPFSettings>().RemoteNodeName = remoteNodeName;
+      pecaApp.Settings.Get<WPFSettings>().WindowTitleMode = windowTitleMode;
       if (IsListenersModified) {
         foreach (var listener in peerCast.OutputListeners.ToArray()) {
           peerCast.StopListen(listener);

--- a/PeerCastStation/PeerCastStation.WPF/MainWindow.xaml
+++ b/PeerCastStation/PeerCastStation.WPF/MainWindow.xaml
@@ -21,7 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. -->
         xmlns:l="clr-namespace:PeerCastStation.WPF.Logs"
         xmlns:lc="clr-namespace:PeerCastStation.WPF.CoreSettings"
         xmlns:lb="clr-namespace:PeerCastStation.WPF.ChannelLists"
-        Title="PeerCastStation" Height="600" Width="460" Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}">
+        Title="{Binding WindowTitle}" Height="600" Width="460" Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}">
   <DockPanel>
     <Menu DockPanel.Dock="Top">
       <MenuItem Header="ファイル(_F)">

--- a/PeerCastStation/PeerCastStation.WPF/WPFSettings.cs
+++ b/PeerCastStation/PeerCastStation.WPF/WPFSettings.cs
@@ -10,6 +10,13 @@ namespace PeerCastStation.WPF
     SessionID,
   }
 
+  [PecaSettings]
+  public enum WindowTitleMode {
+    Simple,
+    Version,
+    ChannelStats,
+  }
+
   [PeerCastStation.Core.PecaSettings]
   public class WPFSettings
   {
@@ -36,6 +43,8 @@ namespace PeerCastStation.WPF
       get { return broadcastHistory; }
       set { broadcastHistory = value; }
     }
+
+    public WindowTitleMode WindowTitleMode { get; set; } = WindowTitleMode.Version;
 
     public WPFSettings()
     {


### PR DESCRIPTION
GUIのタイトルバー文字列を設定でシンプル・バージョン番号付き・チャンネルの視聴/リレー数表示を選択できるようにした。
既定値はバージョン番号付き。

#346 参照