### PR TITLE
.NET Standard 2.0に依存するようになって余計なアセンブリが沢山参照されてしまうのを修正する

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -699,34 +699,6 @@ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTIO
 CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
 OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-.NET Runtime (System.Collections.Immutable.dll)
-================================================
-https://github.com/dotnet/runtime
-
-The MIT License (MIT)
-
-Copyright (c) .NET Foundation and Contributors
-
-All rights reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
 owin-hostring (Owin.dll)
 ==============================
 https://github.com/owin-contrib/owin-hosting/

--- a/PeerCastStation/PecaStationd/PecaStationd.csproj
+++ b/PeerCastStation/PecaStationd/PecaStationd.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>WinExe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/PeerCastStation/PecaStationdDebug/PecaStationdDebug.csproj
+++ b/PeerCastStation/PecaStationdDebug/PecaStationdDebug.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/PeerCastStation/PecaStationdInstaller/PecaStationd.wxs
+++ b/PeerCastStation/PecaStationdInstaller/PecaStationd.wxs
@@ -35,9 +35,6 @@
       <Component Id="Microsoft.Owin.dll" Guid="*">
         <File Id="Microsoft.Owin.dll" Source="$(var.PecaStationd.TargetDir)\Microsoft.Owin.dll" />
       </Component>
-      <Component Id="System.Collections.Immutable.dll" Guid="*">
-        <File Id="System.Collections.Immutable.dll" Source="$(var.PecaStationd.TargetDir)\System.Collections.Immutable.dll" />
-      </Component>
       <Component Id="readme.txt" Guid="*">
         <File Id="readme.txt" Source="$(var.PeerCastStation.ProjectDir)\readme.txt" />
       </Component>

--- a/PeerCastStation/PeerCastStation.ASF/PeerCastStation.ASF.csproj
+++ b/PeerCastStation/PeerCastStation.ASF/PeerCastStation.ASF.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\PeerCastStation\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -12,9 +12,6 @@
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>..\PeerCastStation.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PeerCastStation.Core\PeerCastStation.Core.csproj" />
   </ItemGroup>

--- a/PeerCastStation/PeerCastStation.App/PeerCastStation.App.csproj
+++ b/PeerCastStation/PeerCastStation.App/PeerCastStation.App.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/PeerCastStation/PeerCastStation.Core/ArrayExtension.cs
+++ b/PeerCastStation/PeerCastStation.Core/ArrayExtension.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Linq;
+
+namespace PeerCastStation.Core
+{
+  internal static class ArrayExtension
+  {
+    public static T[] Add<T>(this T[] arr, T value)
+    {
+      var tmp = new T[arr.Length+1];
+      arr.CopyTo(tmp, 0);
+      tmp[arr.Length] = value;
+      return tmp;
+    }
+
+    public static T[] Remove<T>(this T[] arr, T value)
+    {
+      return arr.Where(ent => !ent.Equals(value)).ToArray();
+    }
+
+    public static T[] Clear<T>(this T[] arr)
+    {
+      return Array.Empty<T>();
+    }
+  }
+
+}

--- a/PeerCastStation/PeerCastStation.Core/PeerCast.cs
+++ b/PeerCastStation/PeerCastStation.Core/PeerCast.cs
@@ -21,7 +21,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Linq;
 using Owin;
-using System.Collections.Immutable;
 
 namespace PeerCastStation.Core
 {
@@ -76,12 +75,12 @@ namespace PeerCastStation.Core
     public TimeSpan Uptime { get { return uptime.Elapsed; } }
     private System.Diagnostics.Stopwatch uptime = System.Diagnostics.Stopwatch.StartNew();
 
-    private void ReplaceCollection<T>(ref ImmutableArray<T> collection, Func<ImmutableArray<T>, ImmutableArray<T>> newcollection_func)
+    private void ReplaceCollection<T>(ref T[] collection, Func<T[], T[]> newcollection_func)
     {
       bool replaced;
       do {
         var orig = collection;
-        replaced = ImmutableInterlocked.InterlockedCompareExchange(ref collection, newcollection_func(orig), orig)==orig;
+        replaced = Interlocked.CompareExchange(ref collection, newcollection_func(orig), orig)==orig;
       } while (!replaced);
     }
 
@@ -90,7 +89,7 @@ namespace PeerCastStation.Core
     /// 取得は読み取り専用のリストを、設定は指定したリストのコピーを設定します
     /// </summary>
     public IReadOnlyList<IYellowPageClient> YellowPages { get { return yellowPages; } }
-    private ImmutableArray<IYellowPageClient> yellowPages = ImmutableArray<IYellowPageClient>.Empty;
+    private IYellowPageClient[] yellowPages = Array.Empty<IYellowPageClient>();
 
     /// <summary>
     /// 登録されているYellowPageファクトリのリストを取得します
@@ -114,13 +113,13 @@ namespace PeerCastStation.Core
     /// 接続しているチャンネルの読み取り専用リストを取得します
     /// </summary>
     public IReadOnlyList<Channel> Channels { get { return channels; } }
-    private ImmutableArray<Channel> channels = ImmutableArray<Channel>.Empty;
+    private Channel[] channels = Array.Empty<Channel>();
 
     /// <summary>
     /// 監視オブジェクトのリストを取得します
     /// </summary>
     public IReadOnlyList<IPeerCastMonitor> Monitors { get { return monitors; } }
-    private ImmutableArray<IPeerCastMonitor> monitors = ImmutableArray<IPeerCastMonitor>.Empty;
+    private IPeerCastMonitor[] monitors = Array.Empty<IPeerCastMonitor>();
     private readonly Timer monitorTimer;
 
     private CancellationTokenSource cancelSource = new CancellationTokenSource();
@@ -131,7 +130,7 @@ namespace PeerCastStation.Core
     /// </summary>
     public AccessController AccessController { get; set; }
 
-    private ImmutableArray<OutputListener> outputListeners = ImmutableArray<OutputListener>.Empty;
+    private OutputListener[] outputListeners = Array.Empty<OutputListener>();
     /// <summary>
     /// 接続待ち受けスレッドのコレクションを取得します
     /// </summary>

--- a/PeerCastStation/PeerCastStation.Core/PeerCastStation.Core.csproj
+++ b/PeerCastStation/PeerCastStation.Core/PeerCastStation.Core.csproj
@@ -20,7 +20,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Owin" Version="4.0.1" />
     <PackageReference Include="Owin" Version="1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="ChannelContentReader.cs" />

--- a/PeerCastStation/PeerCastStation.Core/PeerCastStation.Core.csproj
+++ b/PeerCastStation/PeerCastStation.Core/PeerCastStation.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\PeerCastStation\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -13,9 +13,6 @@
     <AssemblyOriginatorKeyFile>..\PeerCastStation.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System.Configuration" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="..\PeerCastStation.snk">
       <Link>PeerCastStation.snk</Link>
     </None>
@@ -23,10 +20,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Owin" Version="4.0.1" />
     <PackageReference Include="Owin" Version="1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="ChannelContentReader.cs" />
     <Compile Remove="EventLogger.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Configuration" />
   </ItemGroup>
 </Project>

--- a/PeerCastStation/PeerCastStation.CustomFilter/PeerCastStation.CustomFilter.csproj
+++ b/PeerCastStation/PeerCastStation.CustomFilter/PeerCastStation.CustomFilter.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/PeerCastStation/PeerCastStation.FLV/PeerCastStation.FLV.csproj
+++ b/PeerCastStation/PeerCastStation.FLV/PeerCastStation.FLV.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\PeerCastStation\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/PeerCastStation/PeerCastStation.HTTP/PeerCastStation.HTTP.csproj
+++ b/PeerCastStation/PeerCastStation.HTTP/PeerCastStation.HTTP.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\PeerCastStation\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -12,12 +12,6 @@
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>..\PeerCastStation.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Update="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PeerCastStation.Core\PeerCastStation.Core.csproj" />
   </ItemGroup>

--- a/PeerCastStation/PeerCastStation.MKV/PeerCastStation.MKV.csproj
+++ b/PeerCastStation/PeerCastStation.MKV/PeerCastStation.MKV.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\PeerCastStation\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/PeerCastStation/PeerCastStation.PCP/PeerCastStation.PCP.csproj
+++ b/PeerCastStation/PeerCastStation.PCP/PeerCastStation.PCP.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\PeerCastStation\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -12,9 +12,6 @@
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>..\PeerCastStation.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PeerCastStation.Core\PeerCastStation.Core.csproj" />
   </ItemGroup>

--- a/PeerCastStation/PeerCastStation.TS/PeerCastStation.TS.csproj
+++ b/PeerCastStation/PeerCastStation.TS/PeerCastStation.TS.csproj
@@ -1,14 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\PeerCastStation.Core\PeerCastStation.Core.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/PeerCastStation/PeerCastStation.Test/PeerCastStation.Test.fsproj
+++ b/PeerCastStation/PeerCastStation.Test/PeerCastStation.Test.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -9,7 +9,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Microsoft.Owin" Version="4.0.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/PeerCastStation/PeerCastStation.UI.HTTP/PeerCastStation.UI.HTTP.csproj
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/PeerCastStation.UI.HTTP.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\PeerCastStation\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/PeerCastStation/PeerCastStation.UI/PeerCastStation.UI.csproj
+++ b/PeerCastStation/PeerCastStation.UI/PeerCastStation.UI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/PeerCastStation/PeerCastStation.WPF/PeerCastStation.WPF.csproj
+++ b/PeerCastStation/PeerCastStation.WPF/PeerCastStation.WPF.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/PeerCastStation/PeerCastStation/PeerCastStation.csproj
+++ b/PeerCastStation/PeerCastStation/PeerCastStation.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <OutputType>WinExe</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\PeerCastStation\</SolutionDir>
@@ -32,9 +32,6 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System.Configuration" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PeerCastStation.App\PeerCastStation.App.csproj" />
     <ProjectReference Include="..\PeerCastStation.ASF\PeerCastStation.ASF.csproj" />

--- a/PeerCastStation/PeerCastStationInstaller/PeerCastStation.wxs
+++ b/PeerCastStation/PeerCastStationInstaller/PeerCastStation.wxs
@@ -22,9 +22,6 @@
 			<Component Id="Owin.dll" Guid="*">
 				<File Id="Owin.dll" Source="$(var.PeerCastStation.TargetDir)\Owin.dll" />
 			</Component>
-      <Component Id="System.Collections.Immutable.dll" Guid="*">
-        <File Id="System.Collections.Immutable.dll" Source="$(var.PeerCastStation.TargetDir)\System.Collections.Immutable.dll" />
-      </Component>
 			<Component Id="readme.txt" Guid="*">
 				<File Id="readme.txt" Source="$(var.PeerCastStation.ProjectDir)\readme.txt" />
 			</Component>


### PR DESCRIPTION
.NET Standard 2.0に依存するようになって余計なアセンブリが沢山参照されてしまっていたので、ターゲットを.NET 4.7.2にした。
また、System.Collections.Immutableへの参照はImmutableArrayしか使っていなかったので普通の配列で代用するようにした。