### PR TITLE
FLV配信でパケットのまとめこみが正しく動いていなかったのを修正する

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/Atom.cs
+++ b/PeerCastStation/PeerCastStation.Core/Atom.cs
@@ -173,7 +173,7 @@ namespace PeerCastStation.Core
     /// <summary>
     /// 中間フレームである
     /// </summary>
-    IntraFrame    = 0x02,
+    InterFrame    = 0x02,
     /// <summary>
     /// 音声パケットである
     /// </summary>

--- a/PeerCastStation/PeerCastStation.Core/Content.cs
+++ b/PeerCastStation/PeerCastStation.Core/Content.cs
@@ -92,7 +92,7 @@ namespace PeerCastStation.Core
   }
 
   public class ContentCollection
-    : ICollection<Content>
+    : ICollection<Content>, IReadOnlyCollection<Content>
   {
     private struct ContentKey
       : IComparable<ContentKey>

--- a/PeerCastStation/PeerCastStation.Core/Content.cs
+++ b/PeerCastStation/PeerCastStation.Core/Content.cs
@@ -120,7 +120,7 @@ namespace PeerCastStation.Core
 
     private long serial = 0;
     private SortedList<ContentKey, Content> list = new SortedList<ContentKey, Content>();
-    public TimeSpan PacketTimeLimit { get; set; } = TimeSpan.FromSeconds(1);
+    public TimeSpan PacketTimeLimit { get; set; } = TimeSpan.FromSeconds(3);
     private Channel owner;
     public ContentCollection(Channel owner)
     {

--- a/PeerCastStation/PeerCastStation.Core/ContentSink.cs
+++ b/PeerCastStation/PeerCastStation.Core/ContentSink.cs
@@ -98,7 +98,7 @@ namespace PeerCastStation.Core
             var buf = dataBuffer.ToArray();
             while (pos<dataBuffer.Length) {
               int len = Math.Min(buf.Length - pos, LengthThreashold);
-              yield return new Content(stream, timestamp, position + pos, buf, pos, len, contFlag);
+              yield return new Content(stream, timestamp, position + pos, buf, pos, len, flag);
               flag |= PCPChanPacketContinuation.Fragment;
               pos += len;
             }

--- a/PeerCastStation/PeerCastStation.Core/ContentSink.cs
+++ b/PeerCastStation/PeerCastStation.Core/ContentSink.cs
@@ -68,7 +68,7 @@ namespace PeerCastStation.Core
         }
         else if (dataBuffer.Length+content.Data.Length>LengthThreashold) {
           var unified_packets = (dataBuffer.Length+content.Data.Length+LengthThreashold-1) / LengthThreashold;
-          var independent_packets = (dataBuffer.Length+LengthThreashold-1)/LengthThreashold + (content.Data.Length+LengthThreashold)/LengthThreashold;
+          var independent_packets = (dataBuffer.Length+LengthThreashold-1)/LengthThreashold + (content.Data.Length+LengthThreashold-1)/LengthThreashold;
           if (unified_packets<independent_packets) {
             lastTimestamp = content.Timestamp;
             dataBuffer.Write(content.Data, 0, content.Data.Length);

--- a/PeerCastStation/PeerCastStation.Core/ContentSink.cs
+++ b/PeerCastStation/PeerCastStation.Core/ContentSink.cs
@@ -61,7 +61,7 @@ namespace PeerCastStation.Core
                  contFlag!=content.ContFlag ||
                  position+dataBuffer.Length!=content.Position ||
                  Math.Abs((content.Timestamp-lastTimestamp).TotalMilliseconds)>100.0 ||
-                 dataBuffer.Length+content.Data.Length>8*1024) {
+                 dataBuffer.Length+content.Data.Length>15*1024) {
           return false;
         }
         else {

--- a/PeerCastStation/PeerCastStation.FLV/FLVContentBuffer.cs
+++ b/PeerCastStation/PeerCastStation.FLV/FLVContentBuffer.cs
@@ -184,26 +184,6 @@ namespace PeerCastStation.FLV
       position += bytes.Length;
     }
 
-    private PCPChanPacketContinuation GetContentFlags(RTMPMessage content)
-    {
-      var pkttype = content.GetPacketType();
-      switch (pkttype) {
-      case FLVPacketType.AudioData:
-      case FLVPacketType.AACRawData:
-        return PCPChanPacketContinuation.AudioFrame;
-      case FLVPacketType.AACSequenceHeader:
-        return PCPChanPacketContinuation.None;
-      case FLVPacketType.AVCNALUnitInterFrame:
-        return PCPChanPacketContinuation.IntraFrame;
-      case FLVPacketType.AVCEOS:
-      case FLVPacketType.AVCNALUnitKeyFrame:
-      case FLVPacketType.AVCSequenceHeader:
-      case FLVPacketType.VideoData:
-      default:
-        return PCPChanPacketContinuation.None;
-      }
-    }
-
     private void OnContentChanged(RTMPMessage content)
     {
       if (streamIndex<0) {
@@ -212,7 +192,7 @@ namespace PeerCastStation.FLV
       }
       WriteMessage(bodyBuffer, content, timestampOrigin);
       if (bodyBuffer.Length>0) {
-        ContentSink.OnContent(new Content(streamIndex, DateTime.Now-streamOrigin, position, bodyBuffer.ToArray(), GetContentFlags(content)));
+        ContentSink.OnContent(new Content(streamIndex, DateTime.Now-streamOrigin, position, bodyBuffer.ToArray(), PCPChanPacketContinuation.None));
         position += bodyBuffer.Length;
         bodyBuffer.SetLength(0);
       }

--- a/PeerCastStation/PeerCastStation.WPF/ChannelLists/ChannelInfos/ChannelInfoControl.xaml
+++ b/PeerCastStation/PeerCastStation.WPF/ChannelLists/ChannelInfos/ChannelInfoControl.xaml
@@ -76,7 +76,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. -->
         <Label   Grid.Row="6" Grid.Column="0" Content="形式:"/>
         <TextBox Grid.Row="6" Grid.Column="1" IsReadOnly="True" Text="{Binding ContentType, Mode=OneWay}"/>
         <Label   Grid.Row="7" Grid.Column="0" Content="ビットレート:"/>
-        <TextBox Grid.Row="7" Grid.Column="1" IsReadOnly="True" Text="{Binding Bitrate, Mode=OneWay}"/>
+        <Grid  Grid.Row="7" Grid.Column="1" Grid.ColumnSpan="1">
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+          </Grid.ColumnDefinitions>
+          <TextBox Grid.Column="0" IsReadOnly="True" Text="{Binding Bitrate, Mode=OneWay}"/>
+          <Label   Grid.Column="1" Content="バッファ:"/>
+          <TextBox Grid.Column="2" IsReadOnly="True" Text="{Binding Buffer, Mode=OneWay}"/>
+        </Grid>
         <Label   Grid.Row="8" Grid.Column="0" Content="配信・リレー時間:"/>
         <TextBox Grid.Row="8" Grid.Column="1" IsReadOnly="True" Text="{Binding Uptime, Mode=OneWay}"/>
       </Grid>

--- a/PeerCastStation/PeerCastStation.WPF/ChannelLists/ChannelInfos/ChannelInfoControl.xaml
+++ b/PeerCastStation/PeerCastStation.WPF/ChannelLists/ChannelInfos/ChannelInfoControl.xaml
@@ -59,7 +59,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. -->
           <RowDefinition Height="Auto"/>
           <RowDefinition Height="Auto"/>
           <RowDefinition Height="Auto"/>
-          <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Label   Grid.Row="0" Grid.Column="0" Content="チャンネル名:"/>
         <TextBox Grid.Row="0" Grid.Column="1" IsReadOnly="True" Text="{Binding ChannelName, Mode=OneWay}"/>
@@ -76,18 +75,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. -->
         <Label   Grid.Row="6" Grid.Column="0" Content="形式:"/>
         <TextBox Grid.Row="6" Grid.Column="1" IsReadOnly="True" Text="{Binding ContentType, Mode=OneWay}"/>
         <Label   Grid.Row="7" Grid.Column="0" Content="ビットレート:"/>
-        <Grid  Grid.Row="7" Grid.Column="1" Grid.ColumnSpan="1">
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="Auto"/>
-            <ColumnDefinition Width="*"/>
-          </Grid.ColumnDefinitions>
-          <TextBox Grid.Column="0" IsReadOnly="True" Text="{Binding Bitrate, Mode=OneWay}"/>
-          <Label   Grid.Column="1" Content="バッファ:"/>
-          <TextBox Grid.Column="2" IsReadOnly="True" Text="{Binding Buffer, Mode=OneWay}"/>
-        </Grid>
-        <Label   Grid.Row="8" Grid.Column="0" Content="配信・リレー時間:"/>
-        <TextBox Grid.Row="8" Grid.Column="1" IsReadOnly="True" Text="{Binding Uptime, Mode=OneWay}"/>
+        <TextBox Grid.Row="7" Grid.Column="1" IsReadOnly="True" Text="{Binding Bitrate, Mode=OneWay}"/>
       </Grid>
     </GroupBox>
     <GroupBox Header="トラック情報">
@@ -116,5 +104,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. -->
       </Grid>
     </GroupBox>
     <Button HorizontalAlignment="Right" Content="適用" Command="{Binding Update}"/>
+    <GroupBox Header="統計情報">
+      <Grid>
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
+          <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+          <RowDefinition Height="Auto"/>
+          <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Label   Grid.Row="0" Grid.Column="0" Content="配信・リレー時間:"/>
+        <TextBox Grid.Row="0" Grid.Column="1" IsReadOnly="True" Text="{Binding Uptime, Mode=OneWay}"/>
+        <Label   Grid.Row="1" Grid.Column="0" Content="バッファ:"/>
+        <TextBox Grid.Row="1" Grid.Column="1" IsReadOnly="True" Text="{Binding Buffer, Mode=OneWay}"/>
+      </Grid>
+    </GroupBox>
   </StackPanel>
 </UserControl>

--- a/PeerCastStation/PeerCastStation.WPF/ChannelLists/ChannelInfos/ChannelInfoViewModel.cs
+++ b/PeerCastStation/PeerCastStation.WPF/ChannelLists/ChannelInfos/ChannelInfoViewModel.cs
@@ -98,6 +98,13 @@ namespace PeerCastStation.WPF.ChannelLists.ChannelInfos
       private set { SetProperty("Bitrate", ref bitrate, value); }
     }
 
+    private string buffer;
+    public string Buffer
+    {
+      get { return buffer; }
+      private set { SetProperty(nameof(Buffer), ref buffer, value); }
+    }
+
     private string uptime;
     public string Uptime
     {
@@ -216,6 +223,7 @@ namespace PeerCastStation.WPF.ChannelLists.ChannelInfos
         ChannelName = "";
         ContentType = "";
         Bitrate     = "";
+        Buffer      = "";
         Uptime      = "";
         Genre       = "";
         Description = "";
@@ -240,6 +248,13 @@ namespace PeerCastStation.WPF.ChannelLists.ChannelInfos
         ChannelName = info.Name;
         ContentType = info.ContentType;
         Bitrate = String.Format("{0} kbps", info.Bitrate);
+        var contents = channel.Contents;
+        var buffersBytes = contents.Sum(cc => cc.Data.Length);
+        var minBufferBytes = contents.Count>0 ? contents.Min(cc => cc.Data.Length) : 0;
+        var maxBufferBytes = contents.Count>0 ? contents.Max(cc => cc.Data.Length) : 0;
+        var avgBufferBytes = contents.Count>0 ? buffersBytes / contents.Count : 0;
+        var buffersDuration = ((contents.LastOrDefault()?.Timestamp ?? TimeSpan.Zero) - (contents.FirstOrDefault()?.Timestamp ?? TimeSpan.Zero)).TotalSeconds;
+        Buffer  = $"Duration: {buffersDuration:F1}s, Count: {contents.Count} ,Total {buffersBytes/1024} KiB, min. {minBufferBytes} B, max. {maxBufferBytes} B, avg. {avgBufferBytes} B)";
         Uptime  = String.Format(
           "{0:D}:{1:D2}:{2:D2}",
           (int)channel.Uptime.TotalHours,
@@ -250,6 +265,7 @@ namespace PeerCastStation.WPF.ChannelLists.ChannelInfos
         ChannelName = "";
         ContentType = "";
         Bitrate     = "";
+        Buffer      = "";
         Uptime      = "";
       }
       if (IsTracker && IsModified) return;

--- a/PeerCastStation/PeerCastStation.WPF/ChannelViewModel.cs
+++ b/PeerCastStation/PeerCastStation.WPF/ChannelViewModel.cs
@@ -123,6 +123,10 @@ namespace PeerCastStation.WPF
       get { return Model.IsBroadcasting; }
     }
 
+    public IReadOnlyCollection<Content> Contents {
+      get { return Model.Contents; }
+    }
+
     public ChannelInfo ChannelInfo {
       get { return Model.ChannelInfo; }
       set { 


### PR DESCRIPTION
* 継続フラグにパケットの種別を入れていたのが邪魔をしてまとめこみが動かなくなっていたので、継続フラグへのパケット種別は入れないようにした。
* 主にデバッグ用にGUIのチャンネル情報にバッファの状態を表示するようにした。
* パケットのまとめこみ閾値を8kBから15kBに拡大した。
* パケットの再分割まで考慮してパケット数が少なくなるようにまとめこむようにした。