### PR TITLE
バッファ量の集計をする時に例外が出ていたのを修正する

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/Content.cs
+++ b/PeerCastStation/PeerCastStation.Core/Content.cs
@@ -182,6 +182,13 @@ namespace PeerCastStation.Core
       }
     }
 
+    public Content[] ToArray()
+    {
+      lock (list) {
+        return list.Values.ToArray();
+      }
+    }
+
     public bool Remove(Content item)
     {
       bool res;

--- a/PeerCastStation/PeerCastStation.UI.HTTP/AdminHost.cs
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/AdminHost.cs
@@ -84,9 +84,9 @@ namespace PeerCastStation.UI.HTTP
         else                  status = "RECEIVE";
         break;
       }
-      var contents = c.Contents;
+      var contents = c.Contents.ToArray();
       var buffersBytes = contents.Sum(cc => cc.Data.Length);
-      var buffersDuration = ((contents.Newest?.Timestamp ?? TimeSpan.Zero) - (contents.Oldest?.Timestamp ?? TimeSpan.Zero)).TotalSeconds;
+      var buffersDuration = ((contents.LastOrDefault()?.Timestamp ?? TimeSpan.Zero) - (contents.FirstOrDefault()?.Timestamp ?? TimeSpan.Zero)).TotalSeconds;
       return new XElement("channel",
         new XAttribute("id",      c.ChannelID.ToString("N").ToUpper()),
         new XAttribute("name",    c.ChannelInfo.Name ?? ""),

--- a/PeerCastStation/PeerCastStation.WPF/ChannelLists/ChannelInfos/ChannelInfoViewModel.cs
+++ b/PeerCastStation/PeerCastStation.WPF/ChannelLists/ChannelInfos/ChannelInfoViewModel.cs
@@ -248,7 +248,7 @@ namespace PeerCastStation.WPF.ChannelLists.ChannelInfos
         ChannelName = info.Name;
         ContentType = info.ContentType;
         Bitrate = String.Format("{0} kbps", info.Bitrate);
-        var contents = channel.Contents;
+        var contents = channel.GetContents();
         var buffersBytes = contents.Sum(cc => cc.Data.Length);
         var minBufferBytes = contents.Count>0 ? contents.Min(cc => cc.Data.Length) : 0;
         var maxBufferBytes = contents.Count>0 ? contents.Max(cc => cc.Data.Length) : 0;

--- a/PeerCastStation/PeerCastStation.WPF/ChannelViewModel.cs
+++ b/PeerCastStation/PeerCastStation.WPF/ChannelViewModel.cs
@@ -123,8 +123,9 @@ namespace PeerCastStation.WPF
       get { return Model.IsBroadcasting; }
     }
 
-    public IReadOnlyCollection<Content> Contents {
-      get { return Model.Contents; }
+    public IReadOnlyCollection<Content> GetContents()
+    {
+      return Model.Contents.ToArray();
     }
 
     public ChannelInfo ChannelInfo {


### PR DESCRIPTION
バッファ量の集計をする時に別スレッドで変更されてInvalidOperationExceptionが出ていたので、コピーを取ってから集計するようにした。