### PR TITLE
帯域測定のエラー時にエラーメッセージが表示されるようにした。

### DIFF
--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/js/settings.js
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/js/settings.js
@@ -452,7 +452,7 @@ var SettingsViewModel = new function() {
         self.checkBandwidthStatus("帯域測定完了: " + result + "kbps, 設定推奨値: " + rate + "kbps");
       },
       function (err) {
-        self.checkBandwidthStatus("帯域測定失敗。接続できませんでした: " + err);
+        self.checkBandwidthStatus("帯域測定失敗。接続できませんでした: " + err.message);
       }
     );
   };
@@ -466,7 +466,7 @@ var SettingsViewModel = new function() {
         self.checkBandwidthStatus("帯域測定完了: " + result + "kbps, 設定推奨値: " + rate + "kbps");
       },
       function (err) {
-        self.checkBandwidthStatus("帯域測定失敗。接続できませんでした: " + err);
+        self.checkBandwidthStatus("帯域測定失敗。接続できませんでした: " + err.message);
       }
     );
   };


### PR DESCRIPTION
HTML UI  で帯域測定中にある種のエラーが発生した時に、JSON RPC エラーオブジェクト自体が文字列化されて `[object Object]` と表示されていたところを、エラーオブジェクトの `message` キーを表示するように変更しました。

### 変更前
![image](https://user-images.githubusercontent.com/1680210/110251326-536dff00-7fc3-11eb-8190-442631ac6843.png)

### 変更後
![image](https://user-images.githubusercontent.com/1680210/110251394-929c5000-7fc3-11eb-9b2a-ed5c13b08921.png)
