### PR TITLE
チャンネルの終了通知が呼ばれなかったのを修正する

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/Channel.cs
+++ b/PeerCastStation/PeerCastStation.Core/Channel.cs
@@ -499,6 +499,7 @@ namespace PeerCastStation.Core
       foreach (var sink in sinks) {
         sink.OnStop(reason);
       }
+      DispatchMonitorEvent(mon => mon.OnStopped(reason));
     }
 
     private class HostComparer


### PR DESCRIPTION
IChannelMonitor.OnStoppedが呼ばれなかったので、YPへの接続が残りっぱなしになったりチャンネル終了通知が出なかったりしていたのを修正した。

YPへの接続が残りっぱなしになる影響で、同じチャンネルをもう一度建てると同じチャンネルIDに対して以前のチャンネルの情報と新しいチャンネルの情報の両方が同時に送られることになる。
このため、YPに掲載されるチャンネル情報がリセットされたりおかしな値になるおそれがあった。

また、チャンネル終了直後にはチャンネルが終了した情報が送られずに、YPからチャンネルが消えるまで時間がかかる要因となっていた。