### PR TITLE
HTML UIからのプレイリストのダウンロードを使いやすくする

### DIFF
--- a/PeerCastStation/PeerCastStation.HTTP/PlayList.cs
+++ b/PeerCastStation/PeerCastStation.HTTP/PlayList.cs
@@ -66,6 +66,7 @@ namespace PeerCastStation.HTTP
     public Task<byte[]> CreatePlayListAsync(Uri baseuri, IEnumerable<KeyValuePair<string,string>> parameters, CancellationToken cancellationToken)
     {
       var res = new System.Text.StringBuilder();
+      res.AppendLine("#EXTM3U");
       var queries = String.Join("&", parameters.Select(kv => Uri.EscapeDataString(kv.Key) + "=" + Uri.EscapeDataString(kv.Value)));
       foreach (var c in Channels) {
         var url = new UriBuilder(new Uri(baseuri, c.ChannelID.ToString("N").ToUpper() + c.ChannelInfo.ContentExtension));
@@ -73,6 +74,7 @@ namespace PeerCastStation.HTTP
         if (queries!="") {
           url.Query = queries;
         }
+        res.AppendLine($"#EXTINF:-1, {c.ChannelInfo.Name}");
         res.AppendLine(url.ToString());
       }
       return Task.FromResult(System.Text.Encoding.UTF8.GetBytes(res.ToString()));

--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/channels.html
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/channels.html
@@ -71,7 +71,7 @@
       <div class="toolbar" data-spy="affix" data-offset-top="42">
         <div class="toolbar-inner">
           <div class="pull-left" style="margin-left:8px">
-            <a class="btn hastooltip" title="再生" data-placement="right" data-container="body" data-bind="attr: { href: channelPlaylistUrl }, css: { disabled: !channelPlayable() }" href="#"><i class="icon-play"></i></a>
+            <a class="btn hastooltip" title="再生" data-placement="right" data-container="body" data-bind="attr: { href: channelPlaylistUrl, download: channelPlaylistFilename }, css: { disabled: !channelPlayable() }" href="#"><i class="icon-play"></i></a>
             <a class="btn hastooltip" title="お気に入り" data-placement="right" data-container="body" data-bind="css: { disabled: !isChannelSelected() }, click: favChannel" href="#"><i class="icon-heart"></i></a>
           </div>
           <div class="pull-left" style="margin-left:8px">

--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/js/channels.js
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/js/channels.js
@@ -230,6 +230,27 @@ var YPChannelViewModel = function(owner, initial_value, new_channel) {
     var auth_token = owner.authToken();
     return auth_token ? url + '&auth=' + auth_token : url;
   });
+  self.playlistFilename = ko.computed(function () {
+    var ext = "";
+    var protocol = UserConfig.defaultPlayProtocol()[self.infoContentType()] || 'Unknown';
+    switch (protocol) {
+    case 'Unknown':
+      break;
+    case 'MSWMSP':
+      ext = ".asx";
+      break;
+    case 'HTTP':
+      ext = ".m3u";
+      break;
+    case 'RTMP':
+      ext = ".m3u";
+      break;
+    case 'HLS':
+      ext = ".m3u8";
+      break;
+    }
+    return self.infoName().replace(/((^\.)|[:\/\\~$<>?"*|])/g, '_') + ext;
+  });
   self.playlistUrl     = ko.computed(function() {
     var ext = "";
     var parameters = ["tip=" + self.tracker()];
@@ -274,7 +295,10 @@ var YPChannelViewModel = function(owner, initial_value, new_channel) {
 
   self.onOpened = function() {
     if (!self.isPlayable()) return;
-    window.open(self.playlistUrl());
+    var a = document.createElement('a')
+    a.href = self.playlistUrl()
+    a.download = self.playlistFilename()
+    a.click()
   };
 
   self.toString = function() {
@@ -416,6 +440,11 @@ var YPChannelsViewModel = function() {
     if (channel==null) return false;
     return channel.isPlayable();
   });
+  self.channelPlaylistFilename = ko.computed(function () {
+    var channel = self.selectedChannel();
+    if (channel==null || !channel.isPlayable()) return "";
+    return channel.playlistFilename();
+  })
   self.channelPlaylistUrl = ko.computed(function () {
     var channel = self.selectedChannel();
     if (channel==null || !channel.isPlayable()) return "#";

--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/js/play.js
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/js/play.js
@@ -60,6 +60,27 @@ var ChannelViewModel = function(owner, initial_value) {
     var auth_token = owner.authToken();
     return auth_token ? url + '?auth=' + auth_token : url;
   });
+  self.playlistFilename = ko.computed(function () {
+    var ext = "";
+    var protocol = UserConfig.defaultPlayProtocol()[self.infoContentType()] || 'Unknown';
+    switch (protocol) {
+    case 'Unknown':
+      break;
+    case 'MSWMSP':
+      ext = ".asx";
+      break;
+    case 'HTTP':
+      ext = ".m3u";
+      break;
+    case 'RTMP':
+      ext = ".m3u";
+      break;
+    case 'HLS':
+      ext = ".m3u8";
+      break;
+    }
+    return self.infoName().replace(/((^\.)|[:\/\\~$<>?"*|])/g, '_') + ext;
+  });
   self.playlistUrl = ko.computed(function () {
     var ext = "";
     var parameters = [];

--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/js/relays.js
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/js/relays.js
@@ -535,6 +535,27 @@ var ChannelViewModel = function(owner, initial_value) {
     var auth_token = owner.authToken();
     return auth_token ? url + '?auth=' + auth_token : url;
   });
+  self.playlistFilename = ko.computed(function () {
+    var ext = "";
+    var protocol = UserConfig.defaultPlayProtocol()[self.infoContentType()] || 'Unknown';
+    switch (protocol) {
+    case 'Unknown':
+      break;
+    case 'MSWMSP':
+      ext = ".asx";
+      break;
+    case 'HTTP':
+      ext = ".m3u";
+      break;
+    case 'RTMP':
+      ext = ".m3u";
+      break;
+    case 'HLS':
+      ext = ".m3u8";
+      break;
+    }
+    return self.infoName().replace(/((^\.)|[:\/\\~$<>?"*|])/g, '_') + ext;
+  });
   self.playlistUrl = ko.computed(function () {
     var ext = "";
     var parameters = [];

--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/play.html
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/play.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="/Scripts/knockout-2.2.0.js"></script>
     <script type="text/javascript" src="/Scripts/bootstrap.min.js"></script>
     <script type="text/javascript" src="/api/1/peercaststation.js"></script>
+    <script type="text/javascript" src="js/common.js"></script>
     <script type="text/javascript" src="js/play.js"></script>
     <script type="text/javascript">
       $(function() {
@@ -58,7 +59,7 @@
                   <a href="#" class="btn btn-mini" data-bind="click:showInfo" rel="tooltip" title="情報"><i class="icon-info-sign"></i></a>
                 </div>
                 <div class="btn-group">
-                  <a class="btn btn-mini" data-bind="attr: { href: playlistUrl }" rel="tooltip" title="再生"><i class="icon-play"></i></a>
+                  <a class="btn btn-mini" data-bind="attr: { href: playlistUrl, download: playlistFilename }" rel="tooltip" title="再生"><i class="icon-play"></i></a>
                 </div>
               </div>
             </div>

--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/relays.html
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/relays.html
@@ -116,7 +116,7 @@
                   <a href="#" class="btn btn-mini" data-bind="click:showRelayTree" rel="tooltip" title="リレーツリー"><i class="icon-signal"></i></a>
                 </div>
                 <div class="btn-group">
-                  <a class="btn btn-mini" data-bind="attr: { href: playlistUrl }" rel="tooltip" title="再生"><i class="icon-play"></i></a>
+                  <a class="btn btn-mini" data-bind="attr: { href: playlistUrl, download: playlistFilename }" rel="tooltip" title="再生"><i class="icon-play"></i></a>
                   <a href="#" class="btn btn-mini" data-bind="click:bump" rel="tooltip" title="再接続"><i class="icon-repeat"></i></a>
                   <a href="#" class="btn btn-mini" data-bind="click:stop" rel="tooltip" title="停止"><i class="icon-stop"></i></a>
                 </div>


### PR DESCRIPTION
* HTML UIから再生開始しようとしてダウンロードされるプレイリスト名がチャンネルIDをそのままファイル名として判別しづらかったので、チャンネル名をファイル名としてダウンロードできるようにした。
* m3uのプレイリストを開いた時にプレイヤーによってタイトルがURLになってしまうので、チャンネル名をタイトルとして拡張情報に入れるようにした。