### PR TITLE
全体で一つだけ持っていたグローバルIPアドレスを削除してリスナー毎に保持するように徹底する

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/OutputListener.cs
+++ b/PeerCastStation/PeerCastStation.Core/OutputListener.cs
@@ -60,6 +60,18 @@ namespace PeerCastStation.Core
         }
       }
     }
+
+    public IPEndPoint GlobalEndPoint {
+      get {
+        if (globalAddress==null) {
+          return null;
+        }
+        else {
+          return new IPEndPoint(globalAddress, ((IPEndPoint)server.LocalEndpoint).Port);
+        }
+      }
+    }
+
     private bool bound = false;
     private PortStatus portStatus = PortStatus.Unknown;
     public PortStatus Status {

--- a/PeerCastStation/PeerCastStation.Core/PeerCast.cs
+++ b/PeerCastStation/PeerCastStation.Core/PeerCast.cs
@@ -468,35 +468,6 @@ namespace PeerCastStation.Core
       }
     }
 
-    private IPAddress globalAddressV4 = null;
-    private IPAddress globalAddressV6 = null;
-
-    public IPAddress GetGlobalAddress(AddressFamily family)
-    {
-      switch (family) {
-      case AddressFamily.InterNetwork:
-        return globalAddressV4;
-      case AddressFamily.InterNetworkV6:
-        return globalAddressV6;
-      default:
-        throw new NotSupportedException();
-      }
-    }
-
-    public void SetGlobalAddress(IPAddress addr)
-    {
-      switch (addr.AddressFamily) {
-      case AddressFamily.InterNetwork:
-        globalAddressV4 = addr;
-        break;
-      case AddressFamily.InterNetworkV6:
-        globalAddressV6 = addr;
-        break;
-      default:
-        throw new NotSupportedException();
-      }
-    }
-
     /// <summary>
     /// 指定したエンドポイントで接続待ち受けを開始します
     /// </summary>
@@ -539,7 +510,7 @@ namespace PeerCastStation.Core
       var listener = outputListeners.FirstOrDefault(
         x => x.LocalEndPoint.AddressFamily==addr_family &&
              (x.GlobalOutputAccepts & connection_type)!=0);
-      var addr = GetGlobalAddress(addr_family);
+      var addr = listener.GlobalAddress;
       if (listener!=null && addr!=null) {
         return new IPEndPoint(addr, listener.LocalEndPoint.Port);
       }


### PR DESCRIPTION
グローバルIPアドレスがリスナー毎に保持しているものと全体で一つだけ持っていたものが混在しており、正しいグローバルIPアドレスが使えていなかったのでリスナー毎のIPアドレスを使うように統一した。