### PR TITLE
オプションパーサをサブコマンドも扱えるように拡張した

### DIFF
--- a/PeerCastStation/PeerCastStation.App/AppBase.cs
+++ b/PeerCastStation/PeerCastStation.App/AppBase.cs
@@ -44,26 +44,21 @@ namespace PeerCastStation.App
       Args = args;
       basePath = basepath;
       var opts = optionParser.Parse(args);
-      var optSettings = opts.FirstOrDefault(opt => opt.LongName=="--settings");
-      if (optSettings!=null) {
-        SettingsFileName = optSettings.Arguments[0];
+      if (opts.TryGetArgumentOf("--settings", out var optSettings)) {
+        SettingsFileName = optSettings;
       }
       else {
         SettingsFileName = PecaSettings.DefaultFileName;
       }
-      var optLinkPID = opts.FirstOrDefault(opt => opt.LongName=="--linkPID");
-      if (optLinkPID!=null) {
-        int pid = 0;
-        if (Int32.TryParse(optLinkPID.Arguments[0], out pid)) {
-          try {
-            LinkProcess = System.Diagnostics.Process.GetProcessById(pid);
-            LinkProcess.Exited += (sender, ev) => {
-              Stop();
-            };
-            LinkProcess.EnableRaisingEvents = true;
-          }
-          catch (Exception) {
-          }
+      if (opts.TryGetArgumentOf("--linkPID", out var optLinkPID) && Int32.TryParse(optLinkPID, out var pid)) {
+        try {
+          LinkProcess = System.Diagnostics.Process.GetProcessById(pid);
+          LinkProcess.Exited += (sender, ev) => {
+            Stop();
+          };
+          LinkProcess.EnableRaisingEvents = true;
+        }
+        catch (Exception) {
         }
       }
       settings = new PecaSettings(SettingsFileName);

--- a/PeerCastStation/PeerCastStation.App/OptionParser.cs
+++ b/PeerCastStation/PeerCastStation.App/OptionParser.cs
@@ -5,6 +5,214 @@ using System.Linq;
 
 namespace PeerCastStation.App
 {
+  public class ParsedOption
+  {
+    public string LongName { get; private set; }
+    public IReadOnlyList<ParsedOption> Options { get; private set; }
+    public IReadOnlyList<string> Arguments { get; private set; }
+    public IReadOnlyList<string> RawArguments { get; private set; }
+
+    public ParsedOption(string name, IReadOnlyList<ParsedOption> options, IReadOnlyList<string> arguments, IReadOnlyList<string> rawArguments)
+    {
+      LongName = name;
+      Options = options;
+      Arguments = arguments;
+      RawArguments = rawArguments;
+    }
+
+    public ParsedOption(string name, IReadOnlyList<string> arguments)
+      : this(name, Array.Empty<ParsedOption>(), arguments, arguments)
+    {
+    }
+
+    public ParsedOption(string name, string argument)
+      : this(name, new string[] { argument })
+    {
+    }
+
+    public ParsedOption(string name)
+      : this(name, Array.Empty<string>())
+    {
+    }
+
+    public bool HasOption(string name)
+    {
+      return Options.Any(opt => opt.LongName==name);
+    }
+
+    public bool TryGetOption(string name, out ParsedOption option)
+    {
+      option = Options.FirstOrDefault(opt => opt.LongName==name);
+      return option!=null;
+    }
+
+    public bool TryGetArgumentOf(string name, out string value)
+    {
+      var option = Options.FirstOrDefault(opt => opt.LongName==name);
+      if (option!=null && option.Arguments.Count>0) {
+        value = option.Arguments[0];
+        return true;
+      }
+      else {
+        value = null;
+        return false;
+      }
+    }
+
+    public string GetArgumentOf(string name)
+    {
+      if (TryGetArgumentOf(name, out var value)) {
+        return value;
+      }
+      else {
+        throw new KeyNotFoundException($"Argument of {name} is not specified.");
+      }
+    }
+
+    public class Builder
+    {
+      public string LongName { get; }
+      public List<ParsedOption.Builder> Options { get; private set; } = new List<ParsedOption.Builder>();
+      public List<string> Arguments { get; private set; } = new List<string>();
+      public List<string> RawArguments { get; private set; } = new List<string>();
+      public Builder(string name)
+      {
+        LongName = name;
+      }
+
+      public ParsedOption ToParsedOption()
+      {
+        var options = Options.Select(opt => opt.ToParsedOption()).ToArray();
+        var arguments = Arguments;
+        var rawArguments = RawArguments;
+        Options = new List<ParsedOption.Builder>();
+        Arguments = new List<string>();
+        RawArguments = new List<string>();
+        return new ParsedOption(LongName, options, arguments, rawArguments);
+      }
+
+      public bool HasOption(string name)
+      {
+        return Options.Any(opt => opt.LongName==name);
+      }
+
+      public bool AddOption(string name)
+      {
+        if (!Options.Any(opt => opt.LongName==name)) {
+          Options.Add(new ParsedOption.Builder(name));
+        }
+        return true;
+      }
+
+      public bool AddOption(string name, string arg, bool allowMultiple)
+      {
+        var opt = Options.FirstOrDefault(opt => opt.LongName==name);
+        if (opt!=null) {
+          if (allowMultiple || opt.Arguments.Count==0) {
+            opt.Arguments.Add(arg);
+          }
+          else {
+            opt.Arguments[0] = arg;
+          }
+        }
+        else {
+          opt = new ParsedOption.Builder(name);
+          opt.Arguments.Add(arg);
+          Options.Add(opt);
+        }
+        return true;
+      }
+    }
+
+  }
+
+  public class CommandHelpBuilder
+  {
+    public string CommandName { get; }
+    private List<string> options = new List<string>();
+    private List<string> arguments = new List<string>();
+    private List<string> mainCommands = new List<string>();
+    private List<string> subcommands = new List<string>();
+
+    public CommandHelpBuilder(string commandName)
+    {
+      CommandName = commandName;
+    }
+
+    public void AddSubcommand(string name, Action<CommandHelpBuilder> subbuildAction)
+    {
+      var sub = new CommandHelpBuilder(name);
+      subbuildAction(sub);
+      if (String.IsNullOrEmpty(name)) {
+        mainCommands.AddRange(sub.ToHelp());
+      }
+      else {
+        subcommands.AddRange(sub.ToHelp());
+      }
+    }
+
+    public void AddOption(string name)
+    {
+      options.Add(name);
+    }
+
+    public void AddArgument(string name)
+    {
+      arguments.Add(name);
+    }
+
+    public IEnumerable<string> ToHelp()
+    {
+      var prefix = new System.Text.StringBuilder();
+      prefix.Append(CommandName);
+      foreach (var opt in options) {
+        prefix.Append(' ');
+        prefix.Append(opt);
+      }
+      if (mainCommands.Count>0) {
+        foreach (var cmd in mainCommands) {
+          var line = new System.Text.StringBuilder();
+          line.Append(prefix);
+          line.Append(cmd);
+          yield return line.ToString();
+        }
+      }
+      else {
+        var line = new System.Text.StringBuilder();
+        line.Append(prefix);
+        foreach (var arg in arguments) {
+          prefix.Append(' ');
+          prefix.Append(arg);
+        }
+        yield return line.ToString();
+      }
+      foreach (var cmd in subcommands) {
+        var line = new System.Text.StringBuilder();
+        line.Append(prefix);
+        line.Append(' ');
+        line.Append(cmd);
+        yield return line.ToString();
+      }
+    }
+
+  }
+
+  [Flags]
+  public enum OptionType
+  {
+    None = 0,
+    Required = 1,
+    Multiple = 2,
+  }
+
+  public interface IOptionParser
+  {
+    public string Name { get; }
+    OptionType OptionType { get; }
+    bool Parse(ParsedOption.Builder context, ref Span<string> args);
+    void Help(CommandHelpBuilder helpBuilder);
+  }
+
   public enum OptionArg
   {
     None,
@@ -12,14 +220,17 @@ namespace PeerCastStation.App
     Required,
   }
 
-  public class OptionDesc
+  public class OptionDesc : IOptionParser
   {
-    public string LongName { get; private set; }
-    public string ShortName { get; private set; }
-    public OptionArg Argument { get; private set; }
-    public System.Text.RegularExpressions.Regex Regex { get; private set; }
-    public OptionDesc(string optLong, string optShort, OptionArg arg)
+    public OptionType OptionType { get; }
+    public string Name { get { return LongName; } }
+    public string LongName { get; }
+    public string ShortName { get; }
+    public OptionArg Argument { get; }
+    public System.Text.RegularExpressions.Regex Regex { get; }
+    public OptionDesc(string optLong, string optShort=null, OptionArg arg=OptionArg.None, OptionType type=OptionType.None)
     {
+      OptionType = type;
       LongName = optLong;
       ShortName = optShort ?? optLong;
       Argument = arg;
@@ -34,29 +245,119 @@ namespace PeerCastStation.App
       }
     }
 
+    public bool Parse(ParsedOption.Builder context, ref Span<string> args)
+    {
+      if (args.Length==0) {
+        return false;
+      }
+      var md = Regex.Match(args[0]);
+      if (md.Success) {
+        args = args.Slice(1);
+        switch (Argument) {
+        case OptionArg.None:
+          return context.AddOption(LongName);
+        case OptionArg.Optional:
+          if (md.Groups[1].Success) {
+            return context.AddOption(LongName, md.Groups[1].Value, OptionType.HasFlag(OptionType.Multiple));
+          }
+          else if (1<=args.Length && !args[0].StartsWith("-")) {
+            var value = args[0];
+            args = args.Slice(1);
+            return context.AddOption(LongName, value, OptionType.HasFlag(OptionType.Multiple));
+          }
+          else {
+            return context.AddOption(LongName);
+          }
+        case OptionArg.Required:
+          if (md.Groups[1].Success) {
+            return context.AddOption(LongName, md.Groups[1].Value, OptionType.HasFlag(OptionType.Multiple));
+          }
+          else if (1<=args.Length && !args[0].StartsWith("-")) {
+            var value = args[0];
+            args = args.Slice(1);
+            return context.AddOption(LongName, value, OptionType.HasFlag(OptionType.Multiple));
+          }
+          else {
+            throw new OptionParseErrorException($"{LongName}:Argument required");
+          }
+        }
+      }
+      return false;
+    }
+
+    public void Help(CommandHelpBuilder helpBuilder)
+    {
+      switch (Argument) {
+      case OptionArg.None:
+        if (LongName==ShortName) {
+          helpBuilder.AddOption($"[{LongName}]");
+        }
+        else {
+          helpBuilder.AddOption($"[{LongName}|{ShortName}]");
+        }
+        break;
+      case OptionArg.Optional:
+        if (LongName==ShortName) {
+          helpBuilder.AddOption($"[{LongName}[=ARG]]");
+        }
+        else {
+          helpBuilder.AddOption($"[({LongName}[=ARG]|{ShortName} [ARG]]");
+        }
+        break;
+      case OptionArg.Required:
+        if (LongName==ShortName) {
+          helpBuilder.AddOption($"[{LongName}=ARG]");
+        }
+        else {
+          helpBuilder.AddOption($"[{LongName}=ARG|{ShortName} ARG]");
+        }
+        break;
+      }
+    }
   }
 
-  public class ParsedOption
+  public class NamedArgument : IOptionParser
   {
-    public string LongName { get; private set; }
-    public string[] Arguments { get; private set; }
-
-    public ParsedOption(string name, string[] arguments)
+    public OptionType OptionType { get; }
+    public string Name { get; }
+    public NamedArgument(string name, OptionType type=OptionType.None)
     {
-      LongName = name;
-      Arguments = arguments;
+      Name = name;
+      OptionType = type;
     }
 
-    public ParsedOption(string name, string argument)
-      : this(name, new string[] { argument })
+    public bool Parse(ParsedOption.Builder context, ref Span<string> args)
     {
+      if (args.Length==0 || args[0].StartsWith("-")) {
+        return false;
+      }
+      if (OptionType.HasFlag(OptionType.Multiple)) {
+        while (0<args.Length && !args[0].StartsWith("-")) {
+          context.AddOption(Name, args[0], true);
+          args = args.Slice(1);
+        }
+        return true;
+      }
+      else if (!context.HasOption(Name)) {
+        context.AddOption(Name, args[0], false);
+        args = args.Slice(1);
+        return true;
+      }
+      else {
+        return false;
+      }
     }
 
-    public ParsedOption(string name)
-      : this(name, new string[0])
+    public void Help(CommandHelpBuilder helpBuilder)
     {
+      var name = OptionType.HasFlag(OptionType.Multiple) ? $"{Name}..." : Name;
+      if (OptionType.HasFlag(OptionType.Required)) {
+        helpBuilder.AddArgument($"{name}");
+      }
+      else {
+        helpBuilder.AddArgument($"[{name}]");
+      }
     }
-
   }
 
   public class OptionParseErrorException
@@ -73,88 +374,124 @@ namespace PeerCastStation.App
     }
   }
 
-  public class OptionParser
-    : IEnumerable<OptionDesc>
+  public abstract class Command : IOptionParser, IEnumerable
   {
+    public OptionType OptionType { get; } = OptionType.None;
+    public string Name { get; }
+    private List<IOptionParser> options = new List<IOptionParser>();
+    public IReadOnlyList<IOptionParser> Options { get; }
 
-    public static readonly string OtherArguments = "";
-
-    private List<OptionDesc> options = new List<OptionDesc>();
-    public IReadOnlyList<OptionDesc> Options { get; private set; }
-
-    public OptionParser()
+    public Command(string name)
     {
+      Name = name;
       Options = options;
     }
 
-    public void Add(string optLong, string optShort, OptionArg argc)
+    public void Add(string optLong, string optShort=null, OptionArg argc=OptionArg.None)
     {
-      options.Add(new OptionDesc(optLong, optShort, argc));
+      Add(new OptionDesc(optLong, optShort, argc));
     }
 
-    public IReadOnlyList<ParsedOption> Parse(string[] args)
+    public void Add(IOptionParser opt)
     {
-      var results = new List<ParsedOption>();
-      var others = new List<string>();
-      int pos = 0;
-      while (pos<args.Length) {
-        var opt = options.FirstOrDefault(o => o.Regex.IsMatch(args[pos]));
-        if (opt!=null) {
-          var md = opt.Regex.Match(args[pos]);
-          switch (opt.Argument) {
-          case OptionArg.None:
-            results.Add(new ParsedOption(opt.LongName));
-            break;
-          case OptionArg.Optional:
-            if (md.Groups[1].Success) {
-              results.Add(new ParsedOption(opt.LongName, md.Groups[1].Value));
-            }
-            else if (pos+1<args.Length && !args[pos+1].StartsWith("-")) {
-              results.Add(new ParsedOption(opt.LongName, args[pos+1]));
-              pos += 1;
-            }
-            else {
-              results.Add(new ParsedOption(opt.LongName));
-            }
-            break;
-          case OptionArg.Required:
-            if (md.Groups[1].Success) {
-              results.Add(new ParsedOption(opt.LongName, md.Groups[1].Value));
-            }
-            else if (pos+1<args.Length && !args[pos+1].StartsWith("-")) {
-              results.Add(new ParsedOption(opt.LongName, args[pos+1]));
-              pos += 1;
-            }
-            else {
-              throw new OptionParseErrorException($"{opt.LongName}:Argument required");
-            }
-            break;
-          }
+      options.Add(opt);
+    }
+
+    public virtual bool Parse(ParsedOption.Builder context, ref Span<string> args)
+    {
+      var result = new ParsedOption.Builder(Name);
+      result.RawArguments.AddRange(args.ToArray());
+      while (args.Length>0) {
+        var parsed = false;
+        foreach (var opt in options) {
+          parsed = opt.Parse(result, ref args) || parsed;
         }
-        else if (args[pos]=="--") {
-          others.AddRange(args.Skip(pos+1));
-          pos = args.Length;
+        if (!parsed) {
+          result.Arguments.Add(args[0]);
+          args = args.Slice(1);
         }
-        else if (args[pos].StartsWith("-")) {
-          throw new OptionParseErrorException($"Unknown option:{args[pos]}");
-        }
-        else {
-          others.Add(args[pos]);
-        }
-        pos += 1;
       }
-      results.Add(new ParsedOption(OtherArguments, others.ToArray()));
-      return results;
+      foreach (var opt in options) {
+        if (opt.OptionType.HasFlag(OptionType.Required) && !result.HasOption(opt.Name)) {
+          throw new OptionParseErrorException($"{opt.Name} must be specified.");
+        }
+      }
+      context.Options.Add(result);
+      return true;
     }
 
-    public IEnumerator<OptionDesc> GetEnumerator()
+    public IEnumerator GetEnumerator()
     {
-      return options.GetEnumerator();
+      throw new NotImplementedException();
     }
 
-    IEnumerator IEnumerable.GetEnumerator()
+    public abstract void Help(CommandHelpBuilder helpBuilder);
+
+  }
+  public class Subcommand : Command
+  {
+    public Subcommand(string name)
+      : base(name)
     {
-      return options.GetEnumerator();
+    }
+
+    public override bool Parse(ParsedOption.Builder context, ref Span<string> args)
+    {
+      if (String.IsNullOrEmpty(Name)) {
+        return base.Parse(context, ref args);
+      }
+      else {
+        if (args.Length==0 || args[0]!=Name) {
+          return false;
+        }
+        args = args.Slice(1);
+        return base.Parse(context, ref args);
+      }
+    }
+
+    public override void Help(CommandHelpBuilder helpBuilder)
+    {
+      helpBuilder.AddSubcommand(Name, builder => {
+        foreach (var opt in Options) {
+          opt.Help(builder);
+        }
+      });
+    }
+
+  }
+
+  public class OptionParser : Command
+  {
+    public OptionParser()
+      : base(System.IO.Path.GetFileName(System.Reflection.Assembly.GetEntryAssembly().Location))
+    {
+    }
+
+    public OptionParser(string programName)
+      : base(programName)
+    {
+    }
+
+    public override void Help(CommandHelpBuilder helpBuilder)
+    {
+      foreach (var opt in Options) {
+        opt.Help(helpBuilder);
+      }
+    }
+
+    public ParsedOption Parse(string[] args)
+    {
+      var argsSpan = args.AsSpan();
+      var result = new ParsedOption.Builder(Name);
+      Parse(result, ref argsSpan);
+      return result.ToParsedOption().Options.First();
+    }
+
+    public string Help()
+    {
+      var builder = new CommandHelpBuilder(Name);
+      Help(builder);
+      return String.Join("\n", builder.ToHelp());
     }
 
   }

--- a/PeerCastStation/PeerCastStation.Test/AppTest.fs
+++ b/PeerCastStation/PeerCastStation.Test/AppTest.fs
@@ -1,0 +1,174 @@
+﻿module AppTest
+
+open Xunit
+open PeerCastStation.App
+open TestCommon
+
+module OptionParserTest =
+    [<Fact>]
+    let ``オプションをパースできる`` () =
+        let opts = OptionParser ()
+        opts.Add("--simpleoption", "-s")
+        opts.Add("--arg-required", "-r", OptionArg.Required)
+        opts.Add("--arg-optional", "-o", OptionArg.Optional)
+
+        let r = opts.Parse(Array.empty)
+        Assert.False(r.HasOption "--simpleoption")
+        Assert.False(r.HasOption "--arg-required")
+        Assert.False(r.HasOption "--arg-optional")
+        Assert.Equal(0, r.Arguments.Count)
+
+        let r = opts.Parse([| "--simpleoption"; "ARG1"; "ARG2" |])
+        Assert.True(r.HasOption "--simpleoption")
+        Assert.False(r.HasOption "--arg-required")
+        Assert.False(r.HasOption "--arg-optional")
+        Assert.Equal(2, r.Arguments.Count)
+        Assert.Equal("ARG1", r.Arguments[0])
+        Assert.Equal("ARG2", r.Arguments[1])
+
+        let r = opts.Parse([| "--simpleoption"; "--arg-required=ARG1"; "--arg-optional"; "ARG2"; "ARG3" |])
+        Assert.True(r.HasOption "--simpleoption")
+        Assert.True(r.HasOption "--arg-required")
+        Assert.Equal("ARG1", r.GetArgumentOf("--arg-required"))
+        Assert.True(r.HasOption "--arg-optional")
+        Assert.Equal("ARG2", r.GetArgumentOf("--arg-optional"))
+        Assert.Equal(1, r.Arguments.Count)
+        Assert.Equal("ARG3", r.Arguments[0])
+
+        let r = opts.Parse([| "-s"; "-r=ARG1"; "-o"; "ARG2"; "ARG3" |])
+        Assert.True(r.HasOption "--simpleoption")
+        Assert.True(r.HasOption "--arg-required")
+        Assert.Equal("ARG1", r.GetArgumentOf("--arg-required"))
+        Assert.True(r.HasOption "--arg-optional")
+        Assert.Equal("ARG2", r.GetArgumentOf("--arg-optional"))
+        Assert.Equal(1, r.Arguments.Count)
+        Assert.Equal("ARG3", r.Arguments[0])
+
+        Assert.Throws<OptionParseErrorException>(fun () ->
+            opts.Parse([| "--arg-required"; |]) |> ignore
+        ) |> ignore
+
+        Assert.Throws<OptionParseErrorException>(fun () ->
+            opts.Parse([| "--arg-required"; "-s" |]) |> ignore
+        ) |> ignore
+
+        let r = opts.Parse([| "--arg-optional"; |])
+        Assert.True(r.HasOption "--arg-optional")
+        let (_, v) = r.TryGetOption("--arg-optional")
+        Assert.Equal(0, v.Arguments.Count)
+
+        let r = opts.Parse([| "--arg-optional"; "-s" |])
+        Assert.True(r.HasOption "--simpleoption")
+        Assert.True(r.HasOption "--arg-optional")
+        let (_, v) = r.TryGetOption("--arg-optional")
+        Assert.Equal(0, v.Arguments.Count)
+
+    [<Fact>]
+    let ``名前付き引数をパースできる`` () =
+        let opts = OptionParser ()
+        opts.Add("--simpleoption", "-s")
+        opts.Add("--arg-required", "-r", OptionArg.Required)
+        opts.Add("--arg-optional", "-o", OptionArg.Optional)
+        opts.Add(NamedArgument("REQUIREDARG", OptionType.Required))
+        opts.Add(NamedArgument("OPTIONALARG", OptionType.None))
+
+        Assert.Throws<OptionParseErrorException>(fun () ->
+            opts.Parse(Array.empty) |> ignore
+        ) |> ignore
+
+        let r = opts.Parse([| "--simpleoption"; "ARG1" |])
+        Assert.True(r.HasOption "--simpleoption")
+        Assert.False(r.HasOption "--arg-required")
+        Assert.False(r.HasOption "--arg-optional")
+        Assert.True(r.HasOption "REQUIREDARG")
+        Assert.False(r.HasOption "OPTIONALARG")
+        Assert.Equal("ARG1", r.GetArgumentOf("REQUIREDARG"))
+        Assert.Equal(0, r.Arguments.Count)
+
+        let r = opts.Parse([| "ARG1"; "ARG2"; "ARG3" |])
+        Assert.True(r.HasOption "REQUIREDARG")
+        Assert.True(r.HasOption "OPTIONALARG")
+        Assert.Equal("ARG1", r.GetArgumentOf("REQUIREDARG"))
+        Assert.Equal("ARG2", r.GetArgumentOf("OPTIONALARG"))
+        Assert.Equal(1, r.Arguments.Count)
+        Assert.Equal("ARG3", r.Arguments[0])
+
+        let r = opts.Parse([| "-s"; "-r=ARG1"; "-o"; "ARG2"; "ARG3"; "ARG4"; "ARG5" |])
+        Assert.True(r.HasOption "--simpleoption")
+        Assert.True(r.HasOption "--arg-required")
+        Assert.Equal("ARG1", r.GetArgumentOf("--arg-required"))
+        Assert.True(r.HasOption "--arg-optional")
+        Assert.Equal("ARG2", r.GetArgumentOf("--arg-optional"))
+        Assert.Equal("ARG3", r.GetArgumentOf("REQUIREDARG"))
+        Assert.Equal("ARG4", r.GetArgumentOf("OPTIONALARG"))
+        Assert.Equal(1, r.Arguments.Count)
+        Assert.Equal("ARG5", r.Arguments[0])
+
+    [<Fact>]
+    let ``サブコマンドをパースできる`` () =
+        let opts = OptionParser ()
+        opts.Add("--simpleoption", "-s")
+        opts.Add("--arg-required", "-r", OptionArg.Required)
+        opts.Add("--arg-optional", "-o", OptionArg.Optional)
+        let subA = Subcommand("suba")
+        subA.Add("--suboption", "-s")
+        subA.Add(NamedArgument("REQUIREDARG", OptionType.Required))
+        subA.Add(NamedArgument("OPTIONALARG", OptionType.None))
+        opts.Add(subA)
+        let subB = Subcommand("subb")
+        subB.Add("--suboption", "-s")
+        subB.Add(NamedArgument("OPTIONALARG", OptionType.None))
+        opts.Add(subB)
+
+        let r = opts.Parse(Array.empty)
+        Assert.False(r.HasOption "--simpleoption")
+        Assert.False(r.HasOption "--arg-required")
+        Assert.False(r.HasOption "--arg-optional")
+        Assert.False(r.HasOption "suba")
+        Assert.False(r.HasOption "subb")
+        Assert.Equal(0, r.Arguments.Count)
+
+        let r = opts.Parse([| "--simpleoption"; "ARG1" |])
+        Assert.True(r.HasOption "--simpleoption")
+        Assert.False(r.HasOption "--arg-required")
+        Assert.False(r.HasOption "--arg-optional")
+        Assert.False(r.HasOption "suba")
+        Assert.False(r.HasOption "subb")
+        Assert.Equal(1, r.Arguments.Count)
+        Assert.Equal("ARG1", r.Arguments[0])
+
+        let r = opts.Parse([| "--simpleoption"; "suba"; "-s"; "ARG1"; "ARG2"; "ARG3" |])
+        Assert.True(r.HasOption "--simpleoption")
+        Assert.False(r.HasOption "--arg-required")
+        Assert.False(r.HasOption "--arg-optional")
+        Assert.True(r.HasOption "suba")
+        Assert.False(r.HasOption "subb")
+        Assert.Equal(0, r.Arguments.Count)
+        let (_, sub) = r.TryGetOption("suba")
+        Assert.True(sub.HasOption "--suboption")
+        Assert.True(sub.HasOption "REQUIREDARG")
+        Assert.True(sub.HasOption "OPTIONALARG")
+        Assert.Equal("ARG1", sub.GetArgumentOf("REQUIREDARG"))
+        Assert.Equal("ARG2", sub.GetArgumentOf("OPTIONALARG"))
+        Assert.Equal(1, sub.Arguments.Count)
+        Assert.Equal("ARG3", sub.Arguments[0])
+
+        Assert.Throws<OptionParseErrorException>(fun () ->
+            opts.Parse([| "--simpleoption"; "suba"; "-s" |]) |> ignore
+        ) |> ignore
+
+        let r = opts.Parse([| "--simpleoption"; "subb"; "-s"; |])
+        Assert.True(r.HasOption "--simpleoption")
+        Assert.False(r.HasOption "--arg-required")
+        Assert.False(r.HasOption "--arg-optional")
+        Assert.False(r.HasOption "suba")
+        Assert.True(r.HasOption "subb")
+        Assert.Equal(0, r.Arguments.Count)
+        let (_, sub) = r.TryGetOption("subb")
+        Assert.True(sub.HasOption "--suboption")
+        Assert.False(sub.HasOption "REQUIREDARG")
+        Assert.False(sub.HasOption "OPTIONALARG")
+        Assert.Equal(0, sub.Arguments.Count)
+
+
+

--- a/PeerCastStation/PeerCastStation.Test/AppTest.fs
+++ b/PeerCastStation/PeerCastStation.Test/AppTest.fs
@@ -23,8 +23,8 @@ module OptionParserTest =
         Assert.False(r.HasOption "--arg-required")
         Assert.False(r.HasOption "--arg-optional")
         Assert.Equal(2, r.Arguments.Count)
-        Assert.Equal("ARG1", r.Arguments[0])
-        Assert.Equal("ARG2", r.Arguments[1])
+        Assert.Equal("ARG1", r.Arguments.[0])
+        Assert.Equal("ARG2", r.Arguments.[1])
 
         let r = opts.Parse([| "--simpleoption"; "--arg-required=ARG1"; "--arg-optional"; "ARG2"; "ARG3" |])
         Assert.True(r.HasOption "--simpleoption")
@@ -33,7 +33,7 @@ module OptionParserTest =
         Assert.True(r.HasOption "--arg-optional")
         Assert.Equal("ARG2", r.GetArgumentOf("--arg-optional"))
         Assert.Equal(1, r.Arguments.Count)
-        Assert.Equal("ARG3", r.Arguments[0])
+        Assert.Equal("ARG3", r.Arguments.[0])
 
         let r = opts.Parse([| "-s"; "-r=ARG1"; "-o"; "ARG2"; "ARG3" |])
         Assert.True(r.HasOption "--simpleoption")
@@ -42,7 +42,7 @@ module OptionParserTest =
         Assert.True(r.HasOption "--arg-optional")
         Assert.Equal("ARG2", r.GetArgumentOf("--arg-optional"))
         Assert.Equal(1, r.Arguments.Count)
-        Assert.Equal("ARG3", r.Arguments[0])
+        Assert.Equal("ARG3", r.Arguments.[0])
 
         Assert.Throws<OptionParseErrorException>(fun () ->
             opts.Parse([| "--arg-required"; |]) |> ignore
@@ -91,7 +91,7 @@ module OptionParserTest =
         Assert.Equal("ARG1", r.GetArgumentOf("REQUIREDARG"))
         Assert.Equal("ARG2", r.GetArgumentOf("OPTIONALARG"))
         Assert.Equal(1, r.Arguments.Count)
-        Assert.Equal("ARG3", r.Arguments[0])
+        Assert.Equal("ARG3", r.Arguments.[0])
 
         let r = opts.Parse([| "-s"; "-r=ARG1"; "-o"; "ARG2"; "ARG3"; "ARG4"; "ARG5" |])
         Assert.True(r.HasOption "--simpleoption")
@@ -102,7 +102,7 @@ module OptionParserTest =
         Assert.Equal("ARG3", r.GetArgumentOf("REQUIREDARG"))
         Assert.Equal("ARG4", r.GetArgumentOf("OPTIONALARG"))
         Assert.Equal(1, r.Arguments.Count)
-        Assert.Equal("ARG5", r.Arguments[0])
+        Assert.Equal("ARG5", r.Arguments.[0])
 
     [<Fact>]
     let ``サブコマンドをパースできる`` () =
@@ -135,7 +135,7 @@ module OptionParserTest =
         Assert.False(r.HasOption "suba")
         Assert.False(r.HasOption "subb")
         Assert.Equal(1, r.Arguments.Count)
-        Assert.Equal("ARG1", r.Arguments[0])
+        Assert.Equal("ARG1", r.Arguments.[0])
 
         let r = opts.Parse([| "--simpleoption"; "suba"; "-s"; "ARG1"; "ARG2"; "ARG3" |])
         Assert.True(r.HasOption "--simpleoption")
@@ -151,7 +151,7 @@ module OptionParserTest =
         Assert.Equal("ARG1", sub.GetArgumentOf("REQUIREDARG"))
         Assert.Equal("ARG2", sub.GetArgumentOf("OPTIONALARG"))
         Assert.Equal(1, sub.Arguments.Count)
-        Assert.Equal("ARG3", sub.Arguments[0])
+        Assert.Equal("ARG3", sub.Arguments.[0])
 
         Assert.Throws<OptionParseErrorException>(fun () ->
             opts.Parse([| "--simpleoption"; "suba"; "-s" |]) |> ignore

--- a/PeerCastStation/PeerCastStation.Test/PeerCastStation.Test.fsproj
+++ b/PeerCastStation/PeerCastStation.Test/PeerCastStation.Test.fsproj
@@ -41,8 +41,7 @@
     <Compile Include="HttpTests.fs" />
     <Compile Include="Tests.fs" />
     <Compile Include="PCPTests.fs" />
+    <Compile Include="AppTest.fs" />
     <Compile Include="UpdaterTests.fs" />
   </ItemGroup>
-
-  <ItemGroup />
 </Project>


### PR DESCRIPTION
アップデート時に呼び出されるサブコマンドでオプションを指定できるようにしたいため、オプションパーサを拡張してサブコマンドやオプションでない引数も統一的に扱えるようにした。