### PR TITLE
HTTPとHLS経由での視聴でチャンネルの視聴上限チェックをしていなかったのを修正する

### DIFF
--- a/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPOutputStream.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPOutputStream.cs
@@ -54,7 +54,7 @@ namespace PeerCastStation.FLV.RTMP
 
     public Channel? RequestChannel(Guid channel_id, Uri? tracker_uri)
     {
-      var channel = peerCast.RequestChannel(channel_id, tracker_uri, true);
+      var channel = peerCast.RequestChannel(channel_id, tracker_uri, request_relay: true);
       this.channel = channel;
       if (channel!=null && channel.IsPlayable(IsLocal)) {
         channel.AddOutputStream(this);

--- a/PeerCastStation/PeerCastStation.Test/TestCommon.fs
+++ b/PeerCastStation/PeerCastStation.Test/TestCommon.fs
@@ -75,6 +75,23 @@ type DummySourceStream (sstype) =
         member this.Dispose () =
             runTask.TrySetResult(StopReason.UserShutdown) |> ignore
 
+type DummyOutputStream () =
+    let connectionInfo = ConnectionInfoBuilder()
+    member this.ConnectionType
+        with get ()    = connectionInfo.Type
+        and  set value = connectionInfo.Type <- value
+    member this.LocalDirects
+        with get ()    = connectionInfo.LocalDirects
+        and  set value = connectionInfo.LocalDirects <- value
+    member this.LocalRelays
+        with get ()    = connectionInfo.LocalRelays
+        and  set value = connectionInfo.LocalRelays <- value
+    interface IChannelSink with
+        member this.OnBroadcast(from, packet) = ()
+        member this.OnStopped(reason) = ()
+        member this.GetConnectionInfo() = connectionInfo.Build()
+
+
 type DummyBroadcastChannel (peercast, network, channelId, sourceStreamFactory) =
     inherit Channel(peercast, network, channelId)
 


### PR DESCRIPTION
HTTPとHLS経由での視聴でチャンネルの視聴上限チェックが抜けていて、帯域や視聴数上限に関係なくいくらでも視聴できていたのを修正しました。

RTMPではチェックしていた。

fix #481