### PR TITLE
PeerCastStation.Core の nullable 解析に不備があったので修正する

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/Http/MapMethodMiddleware.cs
+++ b/PeerCastStation/PeerCastStation.Core/Http/MapMethodMiddleware.cs
@@ -37,7 +37,7 @@ namespace PeerCastStation.Core.Http
     public Task Invoke(IDictionary<string, object> arg)
     {
       var env = new OwinEnvironment(arg);
-      var pathMatch = pathPattern.Match(env.Request.Path);
+      var pathMatch = pathPattern.Match(env.Request.Path ?? "");
       if (pathMatch.Success) {
         if (env.TryGetValue(OwinEnvironment.Owin.RequestMethod, out string? method) && methods.Contains(method)) {
           env.Response.StatusCode = System.Net.HttpStatusCode.OK;

--- a/PeerCastStation/PeerCastStation.Core/Http/OwinEnvironment.cs
+++ b/PeerCastStation/PeerCastStation.Core/Http/OwinEnvironment.cs
@@ -306,7 +306,7 @@ namespace PeerCastStation.Core.Http
         }
         set {
           if (value.HasValue) {
-            env.SetResponseHeader("Content-Length", value.ToString());
+            env.SetResponseHeader("Content-Length", value.Value.ToString());
           }
         }
       }
@@ -557,7 +557,7 @@ namespace PeerCastStation.Core.Http
     public IReadOnlyDictionary<string,string> GetRequestCookies()
     {
       if (cookieCache!=null) return cookieCache;
-      var cookies = GetRequestHeader("Cookie", new string[0]);
+      var cookies = GetRequestHeader("Cookie", new string[0]) ?? Enumerable.Empty<string>();
       var cache = new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase);
       var entries =
         cookies

--- a/PeerCastStation/PeerCastStation.Core/Logger.cs
+++ b/PeerCastStation/PeerCastStation.Core/Logger.cs
@@ -138,7 +138,7 @@ namespace PeerCastStation.Core
     /// </summary>
     public static IList<System.IO.TextWriter> Writers {
       get {
-        return uiListeners.Select(listener => listener.Writer).ToArray();
+        return uiListeners.Select(listener => listener.Writer).NotNull().ToArray();
       }
     }
 
@@ -291,14 +291,16 @@ namespace PeerCastStation.Core
       Trace.Close();
     }
 
-    static private void Output(LogLevel level, string source, string format, params object[] args)
+    static private void Output(LogLevel level, string source, string? format, params object[] args)
     {
-      outputQueue.Enqueue(new LogEntry { Level = level, Source = source, Message = String.Format(format, args) });
+      if (format!=null) {
+        outputQueue.Enqueue(new LogEntry { Level = level, Source = source, Message = String.Format(format, args) });
+      }
     }
 
     static private void Output(LogLevel level, string source, Exception e)
     {
-      Output(level, source, "{0} {1}\n{2}", e.GetType().Name, e.Message, e.StackTrace);
+      Output(level, source, $"{e.GetType().Name} {e.Message}\n{e.StackTrace}");
       if (e.InnerException!=null) {
         Output(level, source, e.InnerException);
       }

--- a/PeerCastStation/PeerCastStation.Core/OutputListener.cs
+++ b/PeerCastStation/PeerCastStation.Core/OutputListener.cs
@@ -230,7 +230,7 @@ namespace PeerCastStation.Core
           while (!cancel_token.IsCancellationRequested) {
             bound = true;
             var client = await server.AcceptTcpClientAsync().ConfigureAwait(false);
-            logger.Info("Client connected {0}", client.Client.RemoteEndPoint);
+            logger.Info($"Client connected {client.Client.RemoteEndPoint}");
             var client_task = ConnectionHandler.HandleClient(
               server.LocalEndpoint,
               client,

--- a/PeerCastStation/PeerCastStation.Core/OutputStreamBase.cs
+++ b/PeerCastStation/PeerCastStation.Core/OutputStreamBase.cs
@@ -208,42 +208,35 @@ namespace PeerCastStation.Core
       var ipv6addr = System.Text.RegularExpressions.Regex.Match(text, @"\A([a-fA-F0-9:.]+)\z");
       var hostaddr = System.Text.RegularExpressions.Regex.Match(text, @"\A([a-zA-Z](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*)\z");
       if (ipv4port.Success) {
-        IPAddress addr;
-        int port;
-        if (IPAddress.TryParse(ipv4port.Groups[1].Value, out addr) &&
+        if (IPAddress.TryParse(ipv4port.Groups[1].Value, out var addr) &&
             addr.AddressFamily==System.Net.Sockets.AddressFamily.InterNetwork &&
-            Int32.TryParse(ipv4port.Groups[2].Value, out port) &&
+            Int32.TryParse(ipv4port.Groups[2].Value, out var port) &&
             0<port && port<=65535) {
           return new IPEndPoint(addr, port).ToString();
         }
       }
       if (ipv6port.Success) {
-        IPAddress addr;
-        int port;
-        if (IPAddress.TryParse(ipv6port.Groups[1].Value, out addr) &&
+        if (IPAddress.TryParse(ipv6port.Groups[1].Value, out var addr) &&
             addr.AddressFamily==System.Net.Sockets.AddressFamily.InterNetworkV6 &&
-            Int32.TryParse(ipv6port.Groups[2].Value, out port) &&
+            Int32.TryParse(ipv6port.Groups[2].Value, out var port) &&
             0<port && port<=65535) {
           return new IPEndPoint(addr, port).ToString();
         }
       }
       if (hostport.Success) {
         string host = hostport.Groups[1].Value;
-        int port;
-        if (Int32.TryParse(hostport.Groups[2].Value, out port) && 0<port && port<=65535) {
+        if (Int32.TryParse(hostport.Groups[2].Value, out var port) && 0<port && port<=65535) {
           return String.Format("{0}:{1}", host, port);
         }
       }
       if (ipv4addr.Success) {
-        IPAddress addr;
-        if (IPAddress.TryParse(ipv4addr.Groups[1].Value, out addr) &&
+        if (IPAddress.TryParse(ipv4addr.Groups[1].Value, out var addr) &&
             addr.AddressFamily==System.Net.Sockets.AddressFamily.InterNetwork) {
           return addr.ToString();
         }
       }
       if (ipv6addr.Success) {
-        IPAddress addr;
-        if (IPAddress.TryParse(ipv6addr.Groups[1].Value, out addr) &&
+        if (IPAddress.TryParse(ipv6addr.Groups[1].Value, out var addr) &&
             addr.AddressFamily==System.Net.Sockets.AddressFamily.InterNetworkV6) {
           return addr.ToString();
         }

--- a/PeerCastStation/PeerCastStation.Core/PeerCast.cs
+++ b/PeerCastStation/PeerCastStation.Core/PeerCast.cs
@@ -327,9 +327,9 @@ namespace PeerCastStation.Core
       this.monitorTimer = new Timer(OnMonitorTimer, cancelSource.Token, 0, 5000);
     }
 
-    private void OnMonitorTimer(object state)
+    private void OnMonitorTimer(object? state)
     {
-      var cs = (CancellationToken)state;
+      var cs = (CancellationToken)state!;
       if (!cs.IsCancellationRequested) {
         DispatchMonitorEvent(mon => mon.OnTimer(), cs);
       }
@@ -375,7 +375,7 @@ namespace PeerCastStation.Core
       }
     }
 
-    private IPAddress GetInterfaceAddress(AddressFamily addr_family)
+    private IPAddress? GetInterfaceAddress(AddressFamily addr_family)
     {
       return System.Net.NetworkInformation.NetworkInterface.GetAllNetworkInterfaces()
         .Where(intf => intf.OperationalStatus==System.Net.NetworkInformation.OperationalStatus.Up)
@@ -510,11 +510,14 @@ namespace PeerCastStation.Core
       var listener = outputListeners.FirstOrDefault(
         x => x.LocalEndPoint.AddressFamily==addr_family &&
              (x.GlobalOutputAccepts & connection_type)!=0);
-      var addr = listener.GlobalAddress;
-      if (listener!=null && addr!=null) {
-        return new IPEndPoint(addr, listener.LocalEndPoint.Port);
+      if (listener==null) {
+        return null;
       }
-      return null;
+      var addr = listener.GlobalAddress;
+      if (addr==null) {
+        return null;
+      }
+      return new IPEndPoint(addr, listener.LocalEndPoint.Port);
     }
 
     public IPEndPoint? GetLocalEndPoint(AddressFamily addr_family, OutputStreamType connection_type)

--- a/PeerCastStation/PeerCastStation.Core/PeerCastStation.Core.csproj
+++ b/PeerCastStation/PeerCastStation.Core/PeerCastStation.Core.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\PeerCastStation\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Nullable>enable</Nullable>
-    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -22,9 +21,5 @@
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.1" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Remove="ChannelContentReader.cs" />
-    <Compile Remove="EventLogger.cs" />
   </ItemGroup>
 </Project>

--- a/PeerCastStation/PeerCastStation.Core/Plugin.cs
+++ b/PeerCastStation/PeerCastStation.Core/Plugin.cs
@@ -98,9 +98,9 @@ namespace PeerCastStation.Core
       var version = info_version!=null ? info_version.InformationalVersion : file_version.FileVersion;
       return new PluginVersionInfo(
         System.IO.Path.GetFileName(asm.Location),
-        asm.FullName,
-        version,
-        file_version.LegalCopyright);
+        asm.FullName ?? "",
+        version ?? "",
+        file_version.LegalCopyright ?? "");
     }
 
     private PeerCastApplication? application = null;

--- a/PeerCastStation/PeerCastStation.Core/WaitableQueue.cs
+++ b/PeerCastStation/PeerCastStation.Core/WaitableQueue.cs
@@ -1,10 +1,12 @@
 ﻿using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace PeerCastStation.Core
 {
   public class WaitableQueue<T>
+    where T : notnull
   {
     private SemaphoreSlim locker = new SemaphoreSlim(0);
     private ConcurrentQueue<T> queue = new ConcurrentQueue<T>();
@@ -17,19 +19,19 @@ namespace PeerCastStation.Core
 
     public async Task<T> DequeueAsync(CancellationToken cancellationToken)
     {
-      T result;
+      T? result;
       while (!queue.TryDequeue(out result)) {
         await locker.WaitAsync(cancellationToken).ConfigureAwait(false);
       }
       return result;
     }
 
-    public bool TryDequeue(out T result)
+    public bool TryDequeue([NotNullWhen(true)] out T? result)
     {
       return queue.TryDequeue(out result);
     }
 
-    public bool TryPeek(out T result)
+    public bool TryPeek([NotNullWhen(true)] out T? result)
     {
       return queue.TryPeek(out result);
     }


### PR DESCRIPTION
PeerCastStation.Core の TargetFramework が .NET Standard 2.1 になっていたせいで、参照している標準ライブラリの nullable ヒントが十分でなく、本来 null になりえるところの解析が抜けていたので、 TargetFramework を .NET 6 にして null の判定を正しく修正した。