### PR TITLE
ポートチェックでタイムアウトで例外が発生すると全てのポートでポートチェック失敗したことになっていたのを修正する

### DIFF
--- a/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingControl.xaml.cs
+++ b/PeerCastStation/PeerCastStation.WPF/CoreSettings/SettingControl.xaml.cs
@@ -51,9 +51,9 @@ namespace PeerCastStation.WPF.CoreSettings
       }
     }
 
-    private void PortCheckButton_Click(object sender, RoutedEventArgs args)
+    private async void PortCheckButton_Click(object sender, RoutedEventArgs args)
     {
-      ((SettingViewModel)this.DataContext).CheckPort();
+      await ((SettingViewModel)this.DataContext).CheckPort();
     }
 
   }


### PR DESCRIPTION
ポートチェックでタイムアウトで例外が発生すると、例外がそのままスルーされて投げられるので、ポートチェック全体が失敗したことになってしまっていた。

例外の内容にかかわらず、ポートチェック時に例外が発生したときには普通に失敗になるようにした。