### PR TITLE
配信チャンネル作成時に初期のトラック情報も設定する

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/BroadcastChannel.cs
+++ b/PeerCastStation/PeerCastStation.Core/BroadcastChannel.cs
@@ -24,11 +24,13 @@ namespace PeerCastStation.Core
         NetworkType network,
         Guid channel_id,
         ChannelInfo channel_info,
+        ChannelTrack channel_track,
         ISourceStreamFactory? source_stream_factory,
         IContentReaderFactory content_reader_factory)
       : base(peercast, network, channel_id)
     {
       this.ChannelInfo = channel_info;
+      this.ChannelTrack = channel_track;
       this.SourceStreamFactory = source_stream_factory;
       this.ContentReaderFactory = content_reader_factory;
     }

--- a/PeerCastStation/PeerCastStation.Core/PeerCast.cs
+++ b/PeerCastStation/PeerCastStation.Core/PeerCast.cs
@@ -234,12 +234,13 @@ namespace PeerCastStation.Core
       IYellowPageClient?    yp,
       Guid                  channel_id,
       ChannelInfo           channel_info,
+      ChannelTrack          channel_track,
       Uri                   source,
       ISourceStreamFactory? source_stream_factory,
       IContentReaderFactory content_reader_factory)
     {
       logger.Debug("Broadcasting channel {0} from {1}", channel_id.ToString("N"), source);
-      var channel = new BroadcastChannel(this, network, channel_id, channel_info, source_stream_factory, content_reader_factory);
+      var channel = new BroadcastChannel(this, network, channel_id, channel_info, channel_track, source_stream_factory, content_reader_factory);
       channel.Start(source);
       ReplaceCollection(ref channels, orig => orig.Add(channel));
       DispatchMonitorEvent(mon => mon.OnChannelChanged(PeerCastChannelAction.Added, channel));

--- a/PeerCastStation/PeerCastStation.Test/ChannelTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/ChannelTests.fs
@@ -10,7 +10,7 @@ open System.Net
 let ``チャンネルがリレー可能な時にMakeRelayableを呼んでもリレー不能なChannelSinkが止められない`` () =
     use peca = new PeerCast()
     peca.AccessController.MaxUpstreamRate <- 6000
-    let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfoBitrate "hoge" "FLV" 500)
+    let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfoBitrate "hoge" "FLV" 500, ChannelTrack.empty)
     peca.AddChannel(channel)
     let relays =
         [| 0; 1; 1; 2; 3; 0 |]
@@ -38,7 +38,7 @@ let ``チャンネルがリレー可能な時にMakeRelayableを呼んでもリ�
 let ``チャンネルがいっぱいの時にMakeRelayableで必要な分だけChannelSinkを止める`` () =
     use peca = new PeerCast()
     peca.AccessController.MaxUpstreamRate <- 3000
-    let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfoBitrate "hoge" "FLV" 500)
+    let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfoBitrate "hoge" "FLV" 500, ChannelTrack.empty)
     peca.AddChannel(channel)
     let relays =
         [| 0; 1; 1; 2; 3; 0 |]
@@ -66,7 +66,7 @@ let ``チャンネルがいっぱいの時にMakeRelayableで必要な分だけC
 let ``チャンネルがいっぱいの時にMakeRelayableで切れる分を切っても新しくリレーできない場合はfalseを返す`` () =
     use peca = new PeerCast()
     peca.AccessController.MaxUpstreamRate <- 2000
-    let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfoBitrate "hoge" "FLV" 500)
+    let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfoBitrate "hoge" "FLV" 500, ChannelTrack.empty)
     peca.AddChannel(channel)
     let relays =
         [| 0; 1; 1; 2; 3; 0 |]
@@ -93,8 +93,8 @@ let ``チャンネルがいっぱいの時にMakeRelayableで切れる分を切�
 [<Fact>]
 let ``指定したキーをBanするとHasBannedがtrueを返す`` () =
     use peca = new PeerCast()
-    let channel1 = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfoBitrate "hoge" "FLV" 500)
-    let channel2 = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfoBitrate "hoge" "FLV" 500)
+    let channel1 = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfoBitrate "hoge" "FLV" 500, ChannelTrack.empty)
+    let channel2 = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfoBitrate "hoge" "FLV" 500, ChannelTrack.empty)
     channel1.Ban("hoge", DateTimeOffset.Now.AddMilliseconds(100.0))
     channel2.Ban("fuga", DateTimeOffset.Now.AddMilliseconds(100.0))
     channel1.Ban("piyo", DateTimeOffset.Now.AddMilliseconds(100.0))
@@ -137,4 +137,19 @@ let ``ノード情報が変更されるとIChannelMonitorのOnNodeChangedが呼�
     Assert.Equal(64, List.length nodes)
     Assert.True(Array.forall (fun h -> List.contains (ChannelNodeAction.Updated, h) nodes) hosts)
     Assert.True(Array.forall (fun h -> List.contains (ChannelNodeAction.Removed, h) nodes) hosts)
+
+
+[<Fact>]
+let ``LoopbackSourceStreamで元のチャンネルのトラック情報がコピーされる`` () =
+    use peca = new PeerCast()
+    let channel1 = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfoBitrate "hoge" "FLV" 500, ChannelTrack.empty)
+    channel1.ChannelTrack <- ChannelTrackDesc.toChannelTrack { ChannelTrackDesc.empty with name=Some "fuga"; album=Some "piyo"; genre=Some "foo"; creator=Some "bar"; url=Some "http://example.com/index.html" }
+    peca.AddChannel channel1
+    channel1.Start("http://example.com/" |> Uri)
+    let channel2 = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfo "hoge" "FLV", ChannelTrack.empty, fun peercast channel uri -> new LoopbackSourceStream(peercast, channel, uri))
+    peca.AddChannel channel2
+    channel2.Start(channel1.ChannelID.ToString("N") |> sprintf "loopback:%s" |> Uri)
+    TestCommon.waitForConditionOrTimeout (fun () -> channel2.ChannelInfo.Bitrate = 500) 1000
+    Assert.Equal(500, channel2.ChannelInfo.Bitrate)
+    Assert.Equal("fuga", channel2.ChannelTrack.Name)
 

--- a/PeerCastStation/PeerCastStation.Test/CoreTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/CoreTests.fs
@@ -8,7 +8,7 @@ open TestCommon
 [<Fact>]
 let ``チャンネルのローカル視聴・リレー数が正しく取れる`` () =
     use peca = new PeerCast()
-    let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfoBitrate "hoge" "FLV" 500)
+    let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfoBitrate "hoge" "FLV" 500, ChannelTrack.empty)
     Assert.Equal(0, channel.LocalDirects)
     Assert.Equal(0, channel.LocalRelays)
     let directs =
@@ -50,7 +50,7 @@ let ``チャンネルのローカル視聴・リレー数が正しく取れる``
 [<Fact>]
 let ``チャンネルの合計視聴・リレー数が正しく取れる`` () =
     use peca = new PeerCast()
-    let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfoBitrate "hoge" "FLV" 500)
+    let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfoBitrate "hoge" "FLV" 500, ChannelTrack.empty)
     Assert.Equal(0, channel.TotalDirects)
     Assert.Equal(0, channel.TotalRelays)
     let directs =

--- a/PeerCastStation/PeerCastStation.Test/HttpTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/HttpTests.fs
@@ -31,7 +31,7 @@ module HttpOutputTest =
     [<Fact>]
     let ``無いチャンネルIDを指定すると404が返る`` () =
         use peca = pecaWithOwinHost endpoint registerHttpDirect
-        let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfoBitrate "hoge" "FLV" 500)
+        let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfoBitrate "hoge" "FLV" 500, ChannelTrack.empty)
         peca.AddChannel channel
         ["pls"; "stream"]
         |> List.iter (fun subpath ->
@@ -65,7 +65,7 @@ module HttpOutputTest =
     [<Fact>]
     let ``視聴数の最大数を超える視聴リクエストには503が返る`` () =
         use peca = pecaWithOwinHost endpoint registerHttpDirect
-        let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfo "hoge" "FLV")
+        let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfo "hoge" "FLV", ChannelTrack.empty)
         peca.AddChannel channel
         peca.AccessController.MaxPlays <- 1
         let channelSink = DummyOutputStream(ConnectionType=ConnectionType.Direct)
@@ -103,7 +103,7 @@ module PlayListTest =
     [<Fact>]
     let ``指定したチャンネルIDのプレイリストが取得できる`` () =
         use peca = pecaWithOwinHost endpoint registerHttpDirect
-        let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfo "hoge" "FLV")
+        let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfo "hoge" "FLV", ChannelTrack.empty)
         peca.AddChannel channel
         let playlist =
             {
@@ -118,7 +118,7 @@ module PlayListTest =
     [<Fact>]
     let ``WMVチャンネルのプレイリストは標準でASXが返る`` () =
         use peca = pecaWithOwinHost endpoint registerHttpDirect
-        let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfo "hoge" "WMV")
+        let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfo "hoge" "WMV", ChannelTrack.empty)
         peca.AddChannel channel
         let playlist =
             {
@@ -133,7 +133,7 @@ module PlayListTest =
     [<Fact>]
     let ``クエリパラメータでスキームを変更できる`` () =
         use peca = pecaWithOwinHost endpoint registerHttpDirect
-        let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfo "hoge" "FLV")
+        let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfo "hoge" "FLV", ChannelTrack.empty)
         peca.AddChannel channel
         let playlist =
             {
@@ -148,7 +148,7 @@ module PlayListTest =
     [<Fact>]
     let ``クエリパラメータか拡張子でフォーマットを変更できる`` () =
         use peca = pecaWithOwinHost endpoint registerHttpDirect
-        let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfo "hoge" "FLV")
+        let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfo "hoge" "FLV", ChannelTrack.empty)
         peca.AddChannel channel
         [
             ("", "http", m3u);
@@ -171,7 +171,7 @@ module PlayListTest =
     [<Fact>]
     let ``m3u8のプレイリストを要求するとhlsのパスにリダイレクトされる`` () =
         use peca = pecaWithOwinHost endpoint registerHttpDirect
-        let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfo "hoge" "FLV")
+        let channel = DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfo "hoge" "FLV", ChannelTrack.empty)
         peca.AddChannel channel
         [
             ("?pls=m3u8", "");

--- a/PeerCastStation/PeerCastStation.UI.HTTP/APIHost.cs
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/APIHost.cs
@@ -1022,22 +1022,22 @@ namespace PeerCastStation.UI.HTTP
         if (channel_info.Name==null || channel_info.Name=="") {
           throw new RPCError(RPCErrorCode.InvalidParams, "Channel name must not be empty");
         }
+        var new_track = new AtomCollection();
+        if (track!=null) {
+          track.TryGetThen("name",    v => new_track.SetChanTrackTitle(v));
+          track.TryGetThen("genre",   v => new_track.SetChanTrackGenre(v));
+          track.TryGetThen("album",   v => new_track.SetChanTrackAlbum(v));
+          track.TryGetThen("creator", v => new_track.SetChanTrackCreator(v));
+          track.TryGetThen("url",     v => new_track.SetChanTrackURL(v));
+        }
+        var channel_track = new ChannelTrack(new_track);
         var channel_id = PeerCastStation.Core.BroadcastChannel.CreateChannelID(
           PeerCast.BroadcastID,
           network_type,
           channel_info.Name,
           channel_info.Genre ?? "",
           source.ToString());
-        var channel = PeerCast.BroadcastChannel(network_type, yp, channel_id, channel_info, source, source_stream, content_reader);
-        if (track!=null) {
-          var new_track = new AtomCollection(channel.ChannelTrack.Extra);
-          track.TryGetThen("name",    v => new_track.SetChanTrackTitle(v));
-          track.TryGetThen("genre",   v => new_track.SetChanTrackGenre(v));
-          track.TryGetThen("album",   v => new_track.SetChanTrackAlbum(v));
-          track.TryGetThen("creator", v => new_track.SetChanTrackCreator(v));
-          track.TryGetThen("url",     v => new_track.SetChanTrackURL(v));
-          channel.ChannelTrack = new ChannelTrack(new_track);
-        }
+        var channel = PeerCast.BroadcastChannel(network_type, yp, channel_id, channel_info, channel_track, source, source_stream, content_reader);
         return channel.ChannelID.ToString("N").ToUpper();
       }
 

--- a/PeerCastStation/PeerCastStation.WPF/ChannelLists/Dialogs/BroadcastViewModel.cs
+++ b/PeerCastStation/PeerCastStation.WPF/ChannelLists/Dialogs/BroadcastViewModel.cs
@@ -345,12 +345,10 @@ namespace PeerCastStation.WPF.ChannelLists.Dialogs
         yellowPage,
         channel_id,
         channelInfo,
+        channelTrack,
         source,
         source_stream,
         contentReaderFactory);
-      if (channel!=null) {
-        channel.ChannelTrack = channelTrack;
-      }
 
       var info = new BroadcastInfoViewModel {
         NetworkType = this.NetworkType,


### PR DESCRIPTION
トラック情報は配信開始後に設定するようにしていたが、他のチャンネルをソースとするとトラック情報の設定が競合することがあるので、配信開始時のトラック情報もチャンネル情報と同時に設定するようにした。