### PR TITLE
終了したチャンネルの SourceStream が再接続を試行する場合があったのを修正する

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/SourceStreamBase.cs
+++ b/PeerCastStation/PeerCastStation.Core/SourceStreamBase.cs
@@ -253,15 +253,17 @@ namespace PeerCastStation.Core
         Queue("CONNECTION_CLEANUP", async () => {
           Logger.Debug($"Cleaning up connection (closed by {args.Reason})");
           OnConnectionStopped(conn.Connection!, args);
-          if (args.Delay>0) {
-            await Task.Delay(args.Delay).ConfigureAwait(false);
-          }
           if (sourceConnection==conn) {
             if (args.IgnoreSource!=null) {
               IgnoreSourceHost(args.IgnoreSource);
             }
             if (args.Reconnect) {
-              DoReconnect();
+              if (args.Delay>0) {
+                await Task.Delay(args.Delay).ConfigureAwait(false);
+              }
+              if (!disposed) {
+                DoReconnect();
+              }
             }
             else if (args.Reason!=StopReason.UserReconnect) {
               DoStopStream(args.Reason);


### PR DESCRIPTION
SourceStream が切断された時に遅延付きの再接続を試行し遅延中に Dispose されると、 Dispose されたにもかかわらず遅延後の再接続を試みるようになっていたのを修正した。