### PR TITLE
HTML UI のリレーページがエラーで空になるのを修正する

### DIFF
--- a/PeerCastStation/PeerCastStation.UI.HTTP/html/js/relays.js
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/html/js/relays.js
@@ -554,7 +554,7 @@ var ChannelViewModel = function(owner, initial_value) {
       ext = ".m3u8";
       break;
     }
-    return self.infoName().replace(/((^\.)|[:\/\\~$<>?"*|])/g, '_') + ext;
+    return (self.infoName() || 'Unknown').replace(/((^\.)|[:\/\\~$<>?"*|])/g, '_') + ext;
   });
   self.playlistUrl = ko.computed(function () {
     var ext = "";


### PR DESCRIPTION
名前が取得できないチャンネルがあった場合 HTML UI のリレーページがエラーで空になっていたのを修正した。