### PR TITLE
送信処理ができなくなった場合はOwinでの処理をキャンセルする

### DIFF
--- a/PeerCastStation/PeerCastStation.Core/Http/OwinContext.cs
+++ b/PeerCastStation/PeerCastStation.Core/Http/OwinContext.cs
@@ -84,10 +84,11 @@ namespace PeerCastStation.Core.Http
       Func<IDictionary<string,object>, Task> func,
       CancellationToken cancellationToken)
     {
-      Environment.Environment[OwinEnvironment.Owin.CallCancelled] = cancellationToken;
+      using var cts = CancellationTokenSource.CreateLinkedTokenSource(ConnectionStream.WriteCompleted, cancellationToken);
+      Environment.Environment[OwinEnvironment.Owin.CallCancelled] = cts.Token;
       await func.Invoke(Environment.Environment).ConfigureAwait(false);
       if (opaqueHandler!=null) {
-        var opaqueEnv = new OpaqueEnvironment(ConnectionStream, cancellationToken);
+        var opaqueEnv = new OpaqueEnvironment(ConnectionStream, cts.Token);
         await opaqueHandler.Invoke(opaqueEnv.Environment).ConfigureAwait(false);
       }
       else {


### PR DESCRIPTION
通信が切断されたなどで送信処理が行えない状態でも、Owinアプリからデータの送信が滞っている場合には実際の送信が行われるまでOwinアプリの処理が継続されるためいつまでも残ってしまうことがあった。

アプリからの送信が無い場合でも一定時間(1秒)毎に送信できるかの確認を行い、送信ができない状態になっていたらOwinアプリの処理をキャンセルするように変更した。