### PR TITLE
HTTP視聴時にLAN内からのアクセスで503が返るのを修正する

### DIFF
--- a/PeerCastStation/PeerCastStation.HTTP/HTTPOutputStream.cs
+++ b/PeerCastStation/PeerCastStation.HTTP/HTTPOutputStream.cs
@@ -104,7 +104,7 @@ namespace PeerCastStation.HTTP
         }
 
         var remoteEndPoint = ctx.Request.GetRemoteEndPoint();
-        if (!channel.IsPlayable(remoteEndPoint.Address.GetAddressLocality()<1)) {
+        if (!channel.IsPlayable(remoteEndPoint.Address.IsSiteLocal())) {
           return (HttpStatusCode.ServiceUnavailable, null!);
         }
 


### PR DESCRIPTION
HTTP視聴の時にLAN内での視聴がローカル扱いされずに残り帯域が足りないと503が返り視聴できなくなっていたのを修正した。