### PR TITLE
ContentCollection が上手くスレッドセーフになっていなかったのを修正する

### DIFF
--- a/PeerCastStation/PeerCastStation.UI.HTTP/AdminHost.cs
+++ b/PeerCastStation/PeerCastStation.UI.HTTP/AdminHost.cs
@@ -84,7 +84,7 @@ namespace PeerCastStation.UI.HTTP
         else                  status = "RECEIVE";
         break;
       }
-      var contents = c.Contents.ToArray();
+      var contents = c.Contents.ToReadOnlyCollection();
       var buffersBytes = contents.Sum(cc => cc.Data.Length);
       var buffersDuration = ((contents.LastOrDefault()?.Timestamp ?? TimeSpan.Zero) - (contents.FirstOrDefault()?.Timestamp ?? TimeSpan.Zero)).TotalSeconds;
       return new XElement("channel",

--- a/PeerCastStation/PeerCastStation.WPF/ChannelViewModel.cs
+++ b/PeerCastStation/PeerCastStation.WPF/ChannelViewModel.cs
@@ -125,7 +125,7 @@ namespace PeerCastStation.WPF
 
     public IReadOnlyCollection<Content> GetContents()
     {
-      return Model.Contents.ToArray();
+      return Model.Contents.ToReadOnlyCollection();
     }
 
     public ChannelInfo ChannelInfo {


### PR DESCRIPTION
ContentCollection が上手くスレッドセーフになっておらず、アクセス時にたまに `ArgumentOutOfRangeException` が投げられることがあったので、内部的に ImmutableSortedSet を使ってスレッドセーフになるようにした。