### PR TITLE
OBSのEnhanced RTMP経由でAV1/HEVC+AACをMKVに乗せて配信できるようにする

### DIFF
--- a/PeerCastStation/PeerCastStation.FLV/PeerCastStation.FLV.csproj
+++ b/PeerCastStation/PeerCastStation.FLV/PeerCastStation.FLV.csproj
@@ -15,6 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\PeerCastStation.Core\PeerCastStation.Core.csproj" />
+    <ProjectReference Include="..\PeerCastStation.MKV\PeerCastStation.MKV.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\PeerCastStation.snk">

--- a/PeerCastStation/PeerCastStation.FLV/Properties/AssemblyInfo.cs
+++ b/PeerCastStation/PeerCastStation.FLV/Properties/AssemblyInfo.cs
@@ -2,6 +2,10 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+// テストプロジェクト(同一 snk で署名)から internal の EnhancedRTMP 等へアクセスするための friend 宣言。
+// 署名アセンブリ間なので full public key の指定が必須(同一 snk なので MKV と同じ値)。
+[assembly: InternalsVisibleTo("PeerCastStation.Test, PublicKey=00240000048000009400000006020000002400005253413100040000010001003b4def7d493cd15e2de42ec2a7edc4f90390af0e8c535e8494b2b4b99e6b95b0c1a6176ee25750801d0698c07dd70f6e131b46e1196e256d5c36d8dd510f73bb5efa555d75bd23d8a93f5f7dbf272876789a3c5f83b8e01914f3e5926b79b61c385a93ef654be66d4ee5f3d485f0d3d94ceecdd96cafc377f7dbf0995b9a5dba")]
+
 // アセンブリに関する一般情報は以下の属性セットをとおして制御されます。
 // アセンブリに関連付けられている情報を変更するには、
 // これらの属性値を変更してください。

--- a/PeerCastStation/PeerCastStation.FLV/RTMP/ERTMPDepacketizer.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/ERTMPDepacketizer.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// (C) 2026 Philmist
 using System;
 
 namespace PeerCastStation.FLV.RTMP

--- a/PeerCastStation/PeerCastStation.FLV/RTMP/ERTMPDepacketizer.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/ERTMPDepacketizer.cs
@@ -147,11 +147,19 @@ namespace PeerCastStation.FLV.RTMP
         frame.Payload = Segment(body, 5);
         return true;
       case VideoPacketTypeCodedFrames:
-        // FourCC の後に 3byte の符号付き CompositionTime が続く。
-        if (body.Length<8) return false;
-        frame.Kind    = DepacketizedFrameKind.CodedFrame;
-        frame.CompositionTimeOffset = ReadSInt24(body, 5);
-        frame.Payload = Segment(body, 8);
+        // 3byte の符号付き CompositionTime は avc1/hvc1 のときだけ存在する(Enhanced RTMP 仕様)。
+        // av01 等は CompositionTime を持たず、FourCC 直後から本体が始まる。FourCC 非依存で
+        // 常に 3byte 読むと av01 の OBU ストリームが 3byte ずれて壊れる(mpv/dav1d がデコード失敗)。
+        frame.Kind = DepacketizedFrameKind.CodedFrame;
+        if (frame.FourCc=="avc1" || frame.FourCc=="hvc1") {
+          if (body.Length<8) return false;
+          frame.CompositionTimeOffset = ReadSInt24(body, 5);
+          frame.Payload = Segment(body, 8);
+        }
+        else {
+          frame.CompositionTimeOffset = 0;
+          frame.Payload = Segment(body, 5);
+        }
         return true;
       case VideoPacketTypeCodedFramesX:
         // CompositionTime 無し(=0)。

--- a/PeerCastStation/PeerCastStation.FLV/RTMP/ERTMPDepacketizer.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/ERTMPDepacketizer.cs
@@ -1,0 +1,260 @@
+using System;
+
+namespace PeerCastStation.FLV.RTMP
+{
+  /// <summary>
+  /// 中間構造体が表すトラック種別。
+  /// </summary>
+  internal enum DepacketizedTrackType
+  {
+    Video,
+    Audio,
+  }
+
+  /// <summary>
+  /// 1 つの RTMP メッセージ(映像/音声)が運ぶデータの種類。
+  /// コーデック非依存で正規化したうえで、Matroska 化(M3/M4)で
+  /// CodecPrivate(SequenceHeader)と SimpleBlock(CodedFrame)に振り分ける。
+  /// </summary>
+  internal enum DepacketizedFrameKind
+  {
+    /// <summary>コーデック設定(avcC/hvcC/av1C/AudioSpecificConfig)。CodecPrivate の元。</summary>
+    SequenceHeader,
+    /// <summary>生フレーム(NALU/OBU/AAC raw)。SimpleBlock の元。</summary>
+    CodedFrame,
+    /// <summary>シーケンス終端。</summary>
+    SequenceEnd,
+    /// <summary>Enhanced RTMP のフレーム単位メタデータ。</summary>
+    Metadata,
+    /// <summary>未対応・解釈不能。</summary>
+    Unknown,
+  }
+
+  /// <summary>
+  /// RTMPMessage(映像/音声)を正規化した、コーデック非依存の中間表現。
+  /// Enhanced RTMP(ExHeader)も旧 FLV(AVC/AAC)も同じ形に正規化する。
+  /// </summary>
+  internal struct DepacketizedFrame
+  {
+    public DepacketizedTrackType TrackType;
+    /// <summary>正規化した FourCC("avc1"/"hvc1"/"av01"/"mp4a" 等)。不明なら空文字。</summary>
+    public string FourCc;
+    public DepacketizedFrameKind Kind;
+    public bool IsKeyFrame;
+    /// <summary>RTMPMessage.Timestamp(デコードタイムスタンプ DTS, ミリ秒)。</summary>
+    public long Timestamp;
+    /// <summary>映像の Composition Time オフセット(符号付き, ミリ秒)。音声や CTS 無しは 0。</summary>
+    public int CompositionTimeOffset;
+    /// <summary>FLV/RTMP のヘッダを剥がしたペイロード(config 本体 or 生フレーム)。</summary>
+    public ArraySegment<byte> Payload;
+  }
+
+  /// <summary>
+  /// RTMPMessage(映像/音声)を <see cref="DepacketizedFrame"/> に正規化する純粋パーサ。
+  /// 副作用を持たないため単体テスト可能(internal、テストへは InternalsVisibleTo で公開)。
+  /// M2 時点では出力はダンプ/ユニットテストのみで、Matroska 化(CodecPrivate/Cluster)は M3/M4。
+  /// </summary>
+  internal static class ERTMPDepacketizer
+  {
+    // 旧 FLV ビデオの CodecID(VideoTagHeader 下位 4bit)。
+    private const int FlvVideoCodecAvc = 7;
+    // 旧 FLV オーディオの SoundFormat(AudioTagHeader 上位 4bit)。
+    private const int FlvAudioFormatAac          = 10;
+    private const int FlvAudioFormatExHeader     = 9; // Enhanced RTMP v2 の音声 ExHeader 識別子(将来対応)
+
+    // Enhanced RTMP video packet type(byte0 の下位 4bit)。
+    private const int VideoPacketTypeSequenceStart        = 0;
+    private const int VideoPacketTypeCodedFrames          = 1;
+    private const int VideoPacketTypeSequenceEnd          = 2;
+    private const int VideoPacketTypeCodedFramesX         = 3;
+    private const int VideoPacketTypeMetadata             = 4;
+    private const int VideoPacketTypeMpeg2TsSequenceStart = 5;
+
+    // Enhanced RTMP の ExHeader を示す byte0 の最上位ビット。
+    private const int ExHeaderFlag = 0x80;
+
+    /// <summary>
+    /// 映像 RTMPMessage を正規化する。解釈不能(短すぎる等)なら false。
+    /// </summary>
+    public static bool TryParseVideo(RTMPMessage msg, out DepacketizedFrame frame)
+    {
+      frame = default;
+      if (msg==null || msg.MessageType!=RTMPMessageType.Video) return false;
+      var body = msg.Body;
+      if (body==null || body.Length<1) return false;
+
+      var b0 = body[0];
+      frame.TrackType = DepacketizedTrackType.Video;
+      frame.Timestamp = msg.Timestamp;
+
+      if ((b0 & ExHeaderFlag)!=0) {
+        return TryParseEnhancedVideo(msg, b0, ref frame);
+      }
+      else {
+        return TryParseLegacyVideo(msg, b0, ref frame);
+      }
+    }
+
+    /// <summary>
+    /// 音声 RTMPMessage を正規化する。当面 AAC を主対象とし、Enhanced 音声 ExHeader は枠のみ。
+    /// </summary>
+    public static bool TryParseAudio(RTMPMessage msg, out DepacketizedFrame frame)
+    {
+      frame = default;
+      if (msg==null || msg.MessageType!=RTMPMessageType.Audio) return false;
+      var body = msg.Body;
+      if (body==null || body.Length<1) return false;
+
+      var b0 = body[0];
+      frame.TrackType = DepacketizedTrackType.Audio;
+      frame.Timestamp = msg.Timestamp;
+      frame.IsKeyFrame = true; // 音声フレームは常にデコード可能とみなす。
+
+      var soundFormat = (b0>>4) & 0x0F;
+      switch (soundFormat) {
+      case FlvAudioFormatAac:
+        return TryParseLegacyAac(msg, ref frame);
+      case FlvAudioFormatExHeader:
+        // Enhanced RTMP v2 の音声 ExHeader(Opus/FLAC/AC-3 等)。将来対応。
+        frame.Kind    = DepacketizedFrameKind.Unknown;
+        frame.FourCc  = "";
+        frame.Payload = new ArraySegment<byte>(body, Math.Min(1, body.Length), Math.Max(0, body.Length-1));
+        return true;
+      default:
+        // MP3 等のその他レガシ音声。当面は本体だけ持たせる(remux 対象外)。
+        frame.Kind    = DepacketizedFrameKind.Unknown;
+        frame.FourCc  = "";
+        frame.Payload = new ArraySegment<byte>(body, Math.Min(1, body.Length), Math.Max(0, body.Length-1));
+        return true;
+      }
+    }
+
+    private static bool TryParseEnhancedVideo(RTMPMessage msg, byte b0, ref DepacketizedFrame frame)
+    {
+      var body = msg.Body;
+      var frameType  = (b0>>4) & 0x07; // bits 4-6
+      var packetType = b0 & 0x0F;      // bits 0-3
+      frame.IsKeyFrame = frameType==1;
+
+      // FourCC(byte1-4)まで必要。
+      if (body.Length<5) return false;
+      frame.FourCc = System.Text.Encoding.ASCII.GetString(body, 1, 4);
+
+      switch (packetType) {
+      case VideoPacketTypeSequenceStart:
+      case VideoPacketTypeMpeg2TsSequenceStart:
+        frame.Kind    = DepacketizedFrameKind.SequenceHeader;
+        frame.Payload = Segment(body, 5);
+        return true;
+      case VideoPacketTypeCodedFrames:
+        // FourCC の後に 3byte の符号付き CompositionTime が続く。
+        if (body.Length<8) return false;
+        frame.Kind    = DepacketizedFrameKind.CodedFrame;
+        frame.CompositionTimeOffset = ReadSInt24(body, 5);
+        frame.Payload = Segment(body, 8);
+        return true;
+      case VideoPacketTypeCodedFramesX:
+        // CompositionTime 無し(=0)。
+        frame.Kind    = DepacketizedFrameKind.CodedFrame;
+        frame.CompositionTimeOffset = 0;
+        frame.Payload = Segment(body, 5);
+        return true;
+      case VideoPacketTypeSequenceEnd:
+        frame.Kind    = DepacketizedFrameKind.SequenceEnd;
+        frame.Payload = Segment(body, 5);
+        return true;
+      case VideoPacketTypeMetadata:
+        frame.Kind    = DepacketizedFrameKind.Metadata;
+        frame.Payload = Segment(body, 5);
+        return true;
+      default:
+        frame.Kind    = DepacketizedFrameKind.Unknown;
+        frame.Payload = Segment(body, 5);
+        return true;
+      }
+    }
+
+    private static bool TryParseLegacyVideo(RTMPMessage msg, byte b0, ref DepacketizedFrame frame)
+    {
+      var body = msg.Body;
+      var frameType = (b0>>4) & 0x0F;
+      var codecId   = b0 & 0x0F;
+      frame.IsKeyFrame = frameType==1;
+      frame.FourCc = codecId==FlvVideoCodecAvc ? "avc1" : "";
+
+      if (codecId==FlvVideoCodecAvc) {
+        // VideoTagHeader: [b0][AVCPacketType][CTS(3)]
+        if (body.Length<2) return false;
+        var avcPacketType = body[1];
+        switch (avcPacketType) {
+        case 0: // AVCDecoderConfigurationRecord(avcC)
+          frame.Kind = DepacketizedFrameKind.SequenceHeader;
+          frame.CompositionTimeOffset = body.Length>=5 ? ReadSInt24(body, 2) : 0;
+          frame.Payload = Segment(body, 5);
+          return true;
+        case 1: // NALU
+          if (body.Length<5) return false;
+          frame.Kind = DepacketizedFrameKind.CodedFrame;
+          frame.CompositionTimeOffset = ReadSInt24(body, 2);
+          frame.Payload = Segment(body, 5);
+          return true;
+        case 2: // end of sequence
+          frame.Kind = DepacketizedFrameKind.SequenceEnd;
+          frame.Payload = Segment(body, Math.Min(5, body.Length));
+          return true;
+        default:
+          frame.Kind = DepacketizedFrameKind.Unknown;
+          frame.Payload = Segment(body, Math.Min(5, body.Length));
+          return true;
+        }
+      }
+      else {
+        // AVC 以外のレガシ映像(Sorenson/VP6 等)。当面 remux 対象外、本体だけ持たせる。
+        frame.Kind = DepacketizedFrameKind.Unknown;
+        frame.Payload = Segment(body, 1);
+        return true;
+      }
+    }
+
+    private static bool TryParseLegacyAac(RTMPMessage msg, ref DepacketizedFrame frame)
+    {
+      var body = msg.Body;
+      // AudioTagHeader: [b0][AACPacketType]
+      if (body.Length<2) return false;
+      frame.FourCc = "mp4a";
+      var aacPacketType = body[1];
+      switch (aacPacketType) {
+      case 0: // AudioSpecificConfig
+        frame.Kind = DepacketizedFrameKind.SequenceHeader;
+        break;
+      case 1: // AAC raw
+        frame.Kind = DepacketizedFrameKind.CodedFrame;
+        break;
+      default:
+        frame.Kind = DepacketizedFrameKind.Unknown;
+        break;
+      }
+      frame.Payload = Segment(body, 2);
+      return true;
+    }
+
+    /// <summary>
+    /// 指定オフセットから末尾までの ArraySegment を作る。offset が範囲外なら空。
+    /// </summary>
+    private static ArraySegment<byte> Segment(byte[] body, int offset)
+    {
+      if (offset>=body.Length) return new ArraySegment<byte>(body, body.Length, 0);
+      return new ArraySegment<byte>(body, offset, body.Length-offset);
+    }
+
+    /// <summary>
+    /// 符号付き 24bit big-endian を読む。RTMPBinaryReader.ReadUInt24 は符号拡張しないため別途用意。
+    /// </summary>
+    private static int ReadSInt24(byte[] body, int offset)
+    {
+      int v = (body[offset]<<16) | (body[offset+1]<<8) | body[offset+2];
+      if ((v & 0x800000)!=0) v -= 0x1000000;
+      return v;
+    }
+  }
+}

--- a/PeerCastStation/PeerCastStation.FLV/RTMP/ERTMPDepacketizer.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/ERTMPDepacketizer.cs
@@ -13,8 +13,8 @@ namespace PeerCastStation.FLV.RTMP
 
   /// <summary>
   /// 1 つの RTMP メッセージ(映像/音声)が運ぶデータの種類。
-  /// コーデック非依存で正規化したうえで、Matroska 化(M3/M4)で
-  /// CodecPrivate(SequenceHeader)と SimpleBlock(CodedFrame)に振り分ける。
+  /// コーデック非依存で正規化したうえで、Matroska化で
+  /// CodecPrivate(SequenceHeader)とSimpleBlock(CodedFrame)に振り分ける。
   /// </summary>
   internal enum DepacketizedFrameKind
   {
@@ -51,16 +51,24 @@ namespace PeerCastStation.FLV.RTMP
 
   /// <summary>
   /// RTMPMessage(映像/音声)を <see cref="DepacketizedFrame"/> に正規化する純粋パーサ。
-  /// 副作用を持たないため単体テスト可能(internal、テストへは InternalsVisibleTo で公開)。
-  /// M2 時点では出力はダンプ/ユニットテストのみで、Matroska 化(CodecPrivate/Cluster)は M3/M4。
   /// </summary>
+  /// <remarks>
+  /// 副作用を持たないため単体テスト可能(internal、テストへは InternalsVisibleTo で公開)。
+  /// </remarks>
   internal static class ERTMPDepacketizer
   {
-    // 旧 FLV ビデオの CodecID(VideoTagHeader 下位 4bit)。
+    /// <summary>
+    /// 旧 FLV ビデオの CodecID(VideoTagHeader 下位 4bit)。
+    /// </summary>
     private const int FlvVideoCodecAvc = 7;
-    // 旧 FLV オーディオの SoundFormat(AudioTagHeader 上位 4bit)。
+    /// <summary>
+    /// 旧 FLV オーディオの SoundFormat(AudioTagHeader 上位 4bit)。
+    /// </summary>
     private const int FlvAudioFormatAac          = 10;
-    private const int FlvAudioFormatExHeader     = 9; // Enhanced RTMP v2 の音声 ExHeader 識別子(将来対応)
+    /// <summary>
+    /// Enhanced RTMP v2 の音声 ExHeader 識別子(将来対応)
+    /// </summary>
+    private const int FlvAudioFormatExHeader     = 9;
 
     // Enhanced RTMP video packet type(byte0 の下位 4bit)。
     private const int VideoPacketTypeSequenceStart        = 0;
@@ -70,11 +78,13 @@ namespace PeerCastStation.FLV.RTMP
     private const int VideoPacketTypeMetadata             = 4;
     private const int VideoPacketTypeMpeg2TsSequenceStart = 5;
 
-    // Enhanced RTMP の ExHeader を示す byte0 の最上位ビット。
+    /// <summary>
+    /// Enhanced RTMP の ExHeader を示す byte0 の最上位ビット。
+    /// </summary>
     private const int ExHeaderFlag = 0x80;
 
     /// <summary>
-    /// 映像 RTMPMessage を正規化する。解釈不能(短すぎる等)なら false。
+    /// 映像RTMPMessageを正規化する。解釈不能(短すぎる等)ならfalse。
     /// </summary>
     public static bool TryParseVideo(RTMPMessage msg, out DepacketizedFrame frame)
     {
@@ -96,7 +106,7 @@ namespace PeerCastStation.FLV.RTMP
     }
 
     /// <summary>
-    /// 音声 RTMPMessage を正規化する。当面 AAC を主対象とし、Enhanced 音声 ExHeader は枠のみ。
+    /// 音声RTMPMessageを正規化する。当面AACを主対象とし、Enhancedな音声のExHeaderは枠のみ。
     /// </summary>
     public static bool TryParseAudio(RTMPMessage msg, out DepacketizedFrame frame)
     {
@@ -115,13 +125,13 @@ namespace PeerCastStation.FLV.RTMP
       case FlvAudioFormatAac:
         return TryParseLegacyAac(msg, ref frame);
       case FlvAudioFormatExHeader:
-        // Enhanced RTMP v2 の音声 ExHeader(Opus/FLAC/AC-3 等)。将来対応。
+        // Enhanced RTMP v2の音声ExHeader(Opus/FLAC/AC-3 等)。将来対応。
         frame.Kind    = DepacketizedFrameKind.Unknown;
         frame.FourCc  = "";
         frame.Payload = new ArraySegment<byte>(body, Math.Min(1, body.Length), Math.Max(0, body.Length-1));
         return true;
       default:
-        // MP3 等のその他レガシ音声。当面は本体だけ持たせる(remux 対象外)。
+        // MP3等のその他レガシ音声。当面は本体だけ持たせる(remux対象外)。
         frame.Kind    = DepacketizedFrameKind.Unknown;
         frame.FourCc  = "";
         frame.Payload = new ArraySegment<byte>(body, Math.Min(1, body.Length), Math.Max(0, body.Length-1));
@@ -147,9 +157,9 @@ namespace PeerCastStation.FLV.RTMP
         frame.Payload = Segment(body, 5);
         return true;
       case VideoPacketTypeCodedFrames:
-        // 3byte の符号付き CompositionTime は avc1/hvc1 のときだけ存在する(Enhanced RTMP 仕様)。
-        // av01 等は CompositionTime を持たず、FourCC 直後から本体が始まる。FourCC 非依存で
-        // 常に 3byte 読むと av01 の OBU ストリームが 3byte ずれて壊れる(mpv/dav1d がデコード失敗)。
+        // 3byteの符号付きCompositionTimeはavc1/hvc1のときだけ存在する(Enhanced RTMP 仕様)。
+        // av01等はCompositionTimeを持たず、FourCC 直後から本体が始まる。FourCC 非依存で
+        // 常に3byte読むとav01のOBUストリームが3byteずれて壊れる(mpv/dav1d がデコード失敗)。
         frame.Kind = DepacketizedFrameKind.CodedFrame;
         if (frame.FourCc=="avc1" || frame.FourCc=="hvc1") {
           if (body.Length<8) return false;

--- a/PeerCastStation/PeerCastStation.FLV/RTMP/EnhancedRTMP.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/EnhancedRTMP.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// (C) 2026 Philmist
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/PeerCastStation/PeerCastStation.FLV/RTMP/EnhancedRTMP.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/EnhancedRTMP.cs
@@ -7,22 +7,28 @@ namespace PeerCastStation.FLV.RTMP
 {
   /// <summary>
   /// Enhanced RTMP の connect 能力交渉に関する純粋なヘルパ。
-  /// 副作用を持たないため単体テスト可能(internal、テストへは InternalsVisibleTo で公開)。
   /// </summary>
+  /// <remarks>
+  /// 副作用を持たないため単体テスト可能(internal、テストへは InternalsVisibleTo で公開)。
+  /// </remarks>
   internal static class EnhancedRTMP
   {
     /// <summary>
     /// サーバがサポートを広告する映像コーデックの FourCC。
-    /// 当面の現実解は AV1/HEVC + AAC で、後方互換として AVC も広告する。
     /// </summary>
+    /// <remarks>
+    /// 当面の現実解は AV1/HEVC + AAC で、後方互換として AVC(H.264) も広告する。
+    /// </remarks>
     public static readonly string[] SupportedVideoFourCc = { "av01", "hvc1", "avc1" };
 
     /// <summary>
     /// connect 応答に載せる拡張能力ビットマスク。
     /// reconnect/multitrack/modEx/nano-timestamp はいずれも未対応なので 0。
     /// フィールド自体を返すことで「Enhanced RTMP を理解するサーバ」であることを示す。
-    /// 各ビットの正確な意味は後続マイルストーン(M2 以降)で必要に応じ精緻化する。
     /// </summary>
+    /// <remarks>
+    /// Enhanced RTMPに対応する機能が実装された場合、この定数を変更する必要がある。
+    /// </remarks>
     public const int CapsEx = 0;
 
     /// <summary>

--- a/PeerCastStation/PeerCastStation.FLV/RTMP/EnhancedRTMP.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/EnhancedRTMP.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PeerCastStation.FLV.AMF;
+
+namespace PeerCastStation.FLV.RTMP
+{
+  /// <summary>
+  /// Enhanced RTMP の connect 能力交渉に関する純粋なヘルパ。
+  /// 副作用を持たないため単体テスト可能(internal、テストへは InternalsVisibleTo で公開)。
+  /// </summary>
+  internal static class EnhancedRTMP
+  {
+    /// <summary>
+    /// サーバがサポートを広告する映像コーデックの FourCC。
+    /// 当面の現実解は AV1/HEVC + AAC で、後方互換として AVC も広告する。
+    /// </summary>
+    public static readonly string[] SupportedVideoFourCc = { "av01", "hvc1", "avc1" };
+
+    /// <summary>
+    /// connect 応答に載せる拡張能力ビットマスク。
+    /// reconnect/multitrack/modEx/nano-timestamp はいずれも未対応なので 0。
+    /// フィールド自体を返すことで「Enhanced RTMP を理解するサーバ」であることを示す。
+    /// 各ビットの正確な意味は後続マイルストーン(M2 以降)で必要に応じ精緻化する。
+    /// </summary>
+    public const int CapsEx = 0;
+
+    /// <summary>
+    /// connect の CommandObject からクライアントが扱える映像コーデックの一覧を抽出する。
+    /// Enhanced RTMP v1 の <c>fourCcList</c>(StrictArray/ECMAArray)を優先し、
+    /// 無ければ v2 の <c>videoFourCcInfoMap</c>(キーが FourCC のマップ)のキーを使う。
+    /// どちらも無ければ空配列を返す。
+    /// </summary>
+    public static IReadOnlyList<string> ParseClientFourCcList(AMFValue commandObject)
+    {
+      if (commandObject==null) return Array.Empty<string>();
+
+      if (commandObject.ContainsKey("fourCcList")) {
+        var list = ReadStringList(commandObject["fourCcList"]);
+        if (list.Count>0) return list;
+      }
+
+      if (commandObject.ContainsKey("videoFourCcInfoMap")) {
+        var keys = ReadMapKeys(commandObject["videoFourCcInfoMap"]);
+        if (keys.Count>0) return keys;
+      }
+
+      return Array.Empty<string>();
+    }
+
+    /// <summary>
+    /// クライアントの FourCC 一覧とサーバのサポート一覧の交差を、
+    /// <see cref="SupportedVideoFourCc"/> の順で返す。
+    /// クライアントが何も指定しなかった(旧 OBS / 非拡張)場合はサポート一覧をそのまま広告する。
+    /// </summary>
+    public static string[] NegotiateVideoFourCc(IReadOnlyList<string> clientList)
+    {
+      if (clientList==null || clientList.Count==0) {
+        return (string[])SupportedVideoFourCc.Clone();
+      }
+      var requested = new HashSet<string>(clientList, StringComparer.OrdinalIgnoreCase);
+      return SupportedVideoFourCc.Where(fourcc => requested.Contains(fourcc)).ToArray();
+    }
+
+    private static IReadOnlyList<string> ReadStringList(AMFValue value)
+    {
+      if (value==null) return Array.Empty<string>();
+      switch (value.Type) {
+      case AMFValueType.StrictArray:
+        return ((AMFValue[])value)
+          .Select(v => (string?)v)
+          .Where(s => !String.IsNullOrEmpty(s))
+          .Select(s => s!)
+          .ToArray();
+      case AMFValueType.ECMAArray:
+        return ReadMapValues(value);
+      default:
+        return Array.Empty<string>();
+      }
+    }
+
+    private static IReadOnlyList<string> ReadMapValues(AMFValue value)
+    {
+      if (value.Value is IDictionary<string,AMFValue> dic) {
+        return dic.Values
+          .Select(v => (string?)v)
+          .Where(s => !String.IsNullOrEmpty(s))
+          .Select(s => s!)
+          .ToArray();
+      }
+      return Array.Empty<string>();
+    }
+
+    private static IReadOnlyList<string> ReadMapKeys(AMFValue value)
+    {
+      if (value==null) return Array.Empty<string>();
+      switch (value.Type) {
+      case AMFValueType.ECMAArray:
+        if (value.Value is IDictionary<string,AMFValue> dic) {
+          return dic.Keys.ToArray();
+        }
+        return Array.Empty<string>();
+      case AMFValueType.Object:
+        return ((AMFObject)value).Select(kv => kv.Key).ToArray();
+      default:
+        return Array.Empty<string>();
+      }
+    }
+  }
+}

--- a/PeerCastStation/PeerCastStation.FLV/RTMP/MatroskaContentBuffer.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/MatroskaContentBuffer.cs
@@ -346,9 +346,20 @@ namespace PeerCastStation.FLV.RTMP
         var track    = isVideo ? VideoTrackNumber : AudioTrackNumber;
         MatroskaWriter.MakeSimpleBlock(track, relative, frame.IsKeyFrame, frame.Payload).Write(ms);
 
+        // 後発参加者のリシンク点を Core の GetFirstContent に正しく伝える。
+        // GetFirstContent は ContFlag==None のパケットを join 点に選ぶので、Cluster を
+        // 開く映像キーフレームのパケットだけを None にする。中間フレーム/音声を None に
+        // すると Cluster 途中(裸の SimpleBlock)から配信が始まり、プレイヤーが
+        // 「Cluster 外の SimpleBlock」として壊れたファイルと判断する(厳格な新しい
+        // mpv 内蔵デマクサで顕著)。
+        var contFlag =
+          (isVideo && frame.IsKeyFrame) ? PCPChanPacketContinuation.None :
+          isVideo                       ? PCPChanPacketContinuation.InterFrame :
+                                          PCPChanPacketContinuation.AudioFrame;
+
         var bytes = ms.ToArray();
         ContentSink.OnContent(
-          new Content(streamIndex, DateTime.Now-streamOrigin, position, bytes, PCPChanPacketContinuation.None));
+          new Content(streamIndex, DateTime.Now-streamOrigin, position, bytes, contFlag));
         position += bytes.Length;
       }
     }

--- a/PeerCastStation/PeerCastStation.FLV/RTMP/MatroskaContentBuffer.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/MatroskaContentBuffer.cs
@@ -12,13 +12,15 @@ namespace PeerCastStation.FLV.RTMP
   ///
   /// onMetaData と 映像+音声の SequenceHeader(config)が揃うと
   /// <see cref="MatroskaInitBuilder.BuildInit"/> で init 領域(EBML/Segment/Info/Tracks)を作り
-  /// OnContentHeader で送出する。以降は映像キーフレームごとに新しい Cluster を開き、
+  /// OnContentHeader で送出する。以降は映像キーフレーム、および前 Cluster から一定時間
+  /// (<see cref="ClusterTimeLimitMs"/>)が経過した映像フレームで新しい Cluster を開き、
   /// 各フレームを SimpleBlock として OnContent で送出する。
   ///
-  /// 「全 Cluster はキーフレームで始まる」を不変条件とし、後発参加者は次の Cluster ID から
-  /// resync できる(既存 MKVContentReader の挙動と対称)。init 完了かつ最初の映像キーフレーム
-  /// 到達までは全フレームを破棄する。低遅延 B フレーム無し運用前提で DTS=PTS とみなす(CTS は M5)。
-  /// 単一映像 + 単一音声トラック前提。
+  /// Cluster を開くパケットを <see cref="PCPChanPacketContinuation.None"/> にすることで、Core の
+  /// GetFirstContent が後発参加者を必ず Cluster 境界から開始させる(Cluster 外の裸 SimpleBlock を
+  /// 配信しない)。GOP が内容バッファ(3秒)より長くても、時間境界 Cluster により直近の join 点が
+  /// バッファ内に残る。init 完了かつ最初の映像キーフレーム到達までは全フレームを破棄する。
+  /// CTS→PTS を適用(avc1/hvc1 は B フレームで CTS が乗る)。単一映像 + 単一音声トラック前提。
   /// </summary>
   internal class MatroskaContentBuffer
     : IRTMPContentSink
@@ -31,6 +33,12 @@ namespace PeerCastStation.FLV.RTMP
     // 映像・音声の config が揃ってから、この数の CodedFrame が来ても onMetaData が
     // 得られない場合は、CodecPrivate だけで init を組み立てる(width/height 不明のまま)。
     private const int MetadataWaitFrames = 60;
+
+    // 後発参加者の join 点(Cluster 境界)は内容バッファ(ContentCollection.PacketTimeLimit
+    // =3秒)に残っている必要がある。GOP がこれより長い配信ではキーフレームが追い出され
+    // join 点が消えてしまうため、キーフレームに加えてこの媒体時間ごとにも新 Cluster を開く。
+    // 3秒より十分短く取る。
+    private const long ClusterTimeLimitMs = 1000;
 
     public Channel      TargetChannel { get; private set; }
     public IContentSink ContentSink   { get; private set; }
@@ -326,36 +334,42 @@ namespace PeerCastStation.FLV.RTMP
       }
       var rebased = pts - timestampOrigin;
 
+      // Cluster を開く条件:映像キーフレーム、または前 Cluster から ClusterTimeLimitMs 以上の
+      // 媒体時間が経過した映像フレーム。後者により GOP が内容バッファ(3秒)より長い配信でも
+      // 直近 Cluster 境界が必ずバッファ内に残り、後発参加者がそこから再生開始できる。
+      // 非キーフレーム始まりの Cluster でもコンテナは有効で、次の本物のキーフレームまで映像は
+      // 乱れるが音声は出る(自己完結タグの FLV 経路と同等の挙動)。Cluster は映像フレームでのみ
+      // 開く(先頭ブロックを映像にし、relative timecode の基準を素直に保つため)。
+      var openCluster =
+        isVideo && (frame.IsKeyFrame ||
+                    rebased - currentClusterTimecode >= ClusterTimeLimitMs);
+
       using (var ms=new MemoryStream()) {
-        // 映像キーフレームごとに新しい Cluster を開く。
-        if (isVideo && frame.IsKeyFrame) {
+        if (openCluster) {
           currentClusterTimecode = rebased;
           MatroskaWriter.MakeUnknownSizeHeader(Elements.Cluster).Write(ms);
           MatroskaWriter.MakeUInt(Elements.Timecode, (ulong)Math.Max(0, currentClusterTimecode)).Write(ms);
         }
-        // §E: 相対 timecode は符号付き int16(±約32.7秒)。Cluster は映像キーフレームでしか
-        //     開かないため、GOP が ~32秒を超えると後半フレームが飽和して timestamp が壊れる。
-        //     Cluster 分割は「全 Cluster はキーフレームで始まる」resync 不変条件を壊すので
-        //     本質修正はせず、検知のみ警告する(通常 GOP ≤4秒では発生しない)。
+        // 相対 timecode は符号付き int16(±約32.7秒)。Cluster を最大 ClusterTimeLimitMs ごとに
+        // 開くため通常は飽和しないが、安全網として検知時に 1 度だけ警告しクランプする。
         var rawRelative = rebased - currentClusterTimecode;
         if ((rawRelative>short.MaxValue || rawRelative<short.MinValue) && !warnedTimecodeSaturation) {
-          Logger.Warn("SimpleBlock relative timecode {0}ms exceeds int16 range; GOP may be too long (>~32s). Timestamp clamped.", rawRelative);
+          Logger.Warn("SimpleBlock relative timecode {0}ms exceeds int16 range; timestamp clamped.", rawRelative);
           warnedTimecodeSaturation = true;
         }
         var relative = (short)Math.Max(short.MinValue, Math.Min(short.MaxValue, rawRelative));
         var track    = isVideo ? VideoTrackNumber : AudioTrackNumber;
         MatroskaWriter.MakeSimpleBlock(track, relative, frame.IsKeyFrame, frame.Payload).Write(ms);
 
-        // 後発参加者のリシンク点を Core の GetFirstContent に正しく伝える。
-        // GetFirstContent は ContFlag==None のパケットを join 点に選ぶので、Cluster を
-        // 開く映像キーフレームのパケットだけを None にする。中間フレーム/音声を None に
-        // すると Cluster 途中(裸の SimpleBlock)から配信が始まり、プレイヤーが
-        // 「Cluster 外の SimpleBlock」として壊れたファイルと判断する(厳格な新しい
-        // mpv 内蔵デマクサで顕著)。
+        // 後発参加者のリシンク点を Core の GetFirstContent に伝える。GetFirstContent は
+        // ContFlag==None のパケットを join 点に選ぶので、Cluster を開くパケット(キーフレーム
+        // および時間境界)を None にする。これにより GOP がバッファより長くても直近 Cluster
+        // から再生開始でき、Cluster 外の裸 SimpleBlock(厳格な新 mpv が壊れ判定)を防ぐ。
+        // 中間映像は InterFrame、音声は AudioFrame。
         var contFlag =
-          (isVideo && frame.IsKeyFrame) ? PCPChanPacketContinuation.None :
-          isVideo                       ? PCPChanPacketContinuation.InterFrame :
-                                          PCPChanPacketContinuation.AudioFrame;
+          openCluster ? PCPChanPacketContinuation.None :
+          isVideo     ? PCPChanPacketContinuation.InterFrame :
+                        PCPChanPacketContinuation.AudioFrame;
 
         var bytes = ms.ToArray();
         ContentSink.OnContent(

--- a/PeerCastStation/PeerCastStation.FLV/RTMP/MatroskaContentBuffer.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/MatroskaContentBuffer.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// (C) 2026 Philmist
 using System;
 using System.IO;
 using PeerCastStation.Core;

--- a/PeerCastStation/PeerCastStation.FLV/RTMP/MatroskaContentBuffer.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/MatroskaContentBuffer.cs
@@ -67,7 +67,7 @@ namespace PeerCastStation.FLV.RTMP
     private long timestampOrigin = 0;
     private long currentClusterTimecode = 0;
 
-    // §B-1: config が揃ってから metadata 無しで経過した CodedFrame 数。
+    // config が揃ってから metadata 無しで経過した CodedFrame 数。
     private int  framesSinceConfigReady = 0;
     private bool metadataFallback       = false;
     // 1 回だけ出す警告のためのフラグ(ログのスパム防止)。
@@ -118,7 +118,7 @@ namespace PeerCastStation.FLV.RTMP
       TrySendInit();
     }
 
-    // §D: onMetaData から bitrate(kbps)を取り出す。無ければ 0。FLVContentBuffer と同方針で
+    // onMetaData から bitrate(kbps)を取り出す。無ければ 0。FLVContentBuffer と同方針で
     // maxBitrate(優先)→videodatarate、それに audiodatarate を加算する。
     private static double ReadBitrate(AMFValue meta)
     {
@@ -140,8 +140,8 @@ namespace PeerCastStation.FLV.RTMP
       return bitrate;
     }
 
-    // §D: ChannelInfo(MKV)を送る。bitrate 不明(0)時は FLVContentBuffer 同様に値を捏造せず
-    //     未設定のままにする(AccessController のリレー計算に誤った値を与えないため)。
+    // ChannelInfo(MKV)を送る。bitrate 不明(0)時は FLVContentBuffer 同様に値を捏造せず
+    // 未設定のままにする(AccessController のリレー計算に誤った値を与えないため)。
     private void SendChannelInfo(double bitrate)
     {
       var info = new AtomCollection();
@@ -172,7 +172,7 @@ namespace PeerCastStation.FLV.RTMP
       }
     }
 
-    // §B-3: パース失敗の連続を検知できるよう最初の数回だけログする(スパム防止)。
+    // パース失敗の連続を検知できるよう最初の数回だけログする(スパム防止)。
     private const int MaxParseFailureLogs = 5;
 
     public void OnVideo(RTMPMessage msg)
@@ -230,7 +230,7 @@ namespace PeerCastStation.FLV.RTMP
       }
     }
 
-    // §B-2: init 送出後に config(コーデック/CodecPrivate)が変わったら Info で可視化する。
+    // init 送出後に config(コーデック/CodecPrivate)が変わったら Info で可視化する。
     // init は再送しない(後発参加者 resync の不変条件を壊さないため)。将来対応の足場。
     private void WarnIfConfigChanged(string kind, string? oldFourCc, byte[]? oldConfig, string newFourCc, byte[] newConfig)
     {
@@ -261,8 +261,8 @@ namespace PeerCastStation.FLV.RTMP
     {
       if (initSent) return;
       if (!ConfigReady) return;
-      // §B-1: 通常は onMetaData(解像度)が揃うのを待つが、来ない配信でも
-      //       metadataFallback が立てば config だけで init を出す(width/height=0)。
+      // 通常は onMetaData(解像度)が揃うのを待つが、来ない配信でも
+      // metadataFallback が立てば config だけで init を出す(width/height=0)。
       if (!hasMetadata && !metadataFallback) return;
 
       // metadata が無いまま init する場合は ChannelInfo(MKV)もここで送っておく。
@@ -301,8 +301,8 @@ namespace PeerCastStation.FLV.RTMP
     private void WriteFrame(DepacketizedFrame frame)
     {
       if (!initSent) {
-        // §B-1: config は揃っているが onMetaData 待ちの間にフレームが来続けたら、
-        //       一定数を超えたところで config だけの init にフォールバックする。
+        // config は揃っているが onMetaData 待ちの間にフレームが来続けたら、
+        // 一定数を超えたところで config だけの init にフォールバックする。
         if (ConfigReady && !hasMetadata && !metadataFallback) {
           if (++framesSinceConfigReady>=MetadataWaitFrames) {
             metadataFallback = true;
@@ -321,8 +321,8 @@ namespace PeerCastStation.FLV.RTMP
         Logger.Debug("First video keyframe reached; starting Matroska cluster output");
       }
 
-      // §A: 提示時刻(PTS)= DTS + CompositionTimeOffset を使う。avc1/hvc1 は B フレームで
-      //     CTS が乗る。av01 は CTS を持たない(常に 0)ので実質 DTS=PTS。
+      // 提示時刻(PTS)= DTS + CompositionTimeOffset を使う。avc1/hvc1 は B フレームで
+      // CTS が乗る。av01 は CTS を持たない(常に 0)ので実質 DTS=PTS。
       if (isVideo && frame.CompositionTimeOffset!=0 && frame.FourCc=="av01" && !warnedUnexpectedCts) {
         Logger.Warn("Unexpected non-zero CTS ({0}ms) on av01 frame; av01 should not carry CompositionTime", frame.CompositionTimeOffset);
         warnedUnexpectedCts = true;

--- a/PeerCastStation/PeerCastStation.FLV/RTMP/MatroskaContentBuffer.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/MatroskaContentBuffer.cs
@@ -1,0 +1,246 @@
+using System;
+using System.IO;
+using PeerCastStation.Core;
+using PeerCastStation.FLV.AMF;
+using PeerCastStation.MKV;
+
+namespace PeerCastStation.FLV.RTMP
+{
+  /// <summary>
+  /// Enhanced RTMP(および旧 FLV)を Matroska へ remux(再エンコード無し)する
+  /// <see cref="IRTMPContentSink"/>。<see cref="FLVContentBuffer"/> の Matroska 版。
+  ///
+  /// onMetaData と 映像+音声の SequenceHeader(config)が揃うと
+  /// <see cref="MatroskaInitBuilder.BuildInit"/> で init 領域(EBML/Segment/Info/Tracks)を作り
+  /// OnContentHeader で送出する。以降は映像キーフレームごとに新しい Cluster を開き、
+  /// 各フレームを SimpleBlock として OnContent で送出する。
+  ///
+  /// 「全 Cluster はキーフレームで始まる」を不変条件とし、後発参加者は次の Cluster ID から
+  /// resync できる(既存 MKVContentReader の挙動と対称)。init 完了かつ最初の映像キーフレーム
+  /// 到達までは全フレームを破棄する。低遅延 B フレーム無し運用前提で DTS=PTS とみなす(CTS は M5)。
+  /// 単一映像 + 単一音声トラック前提。
+  /// </summary>
+  internal class MatroskaContentBuffer
+    : IRTMPContentSink
+  {
+    private const ulong VideoTrackNumber = 1;
+    private const ulong AudioTrackNumber = 2;
+
+    public Channel      TargetChannel { get; private set; }
+    public IContentSink ContentSink   { get; private set; }
+    public long         Position      { get { return position; } }
+
+    private long     position    = 0;
+    private int      streamIndex = -1;
+    private DateTime streamOrigin;
+
+    // config(SequenceHeader)。映像・音声が揃うと init を出せる。
+    private string? videoFourCc      = null;
+    private byte[]? videoCodecPrivate = null;
+    private string? audioFourCc      = null;
+    private byte[]? audioCodecPrivate = null;
+
+    // onMetaData 由来のトラック属性。
+    private bool   hasMetadata = false;
+    private int    pixelWidth        = 0;
+    private int    pixelHeight       = 0;
+    private double samplingFrequency = 48000.0;
+    private int    channels          = 2;
+
+    private bool initSent        = false;
+    private bool seenFirstKeyFrame = false;
+    private bool hasTimestampOrigin = false;
+    private long timestampOrigin = 0;
+    private long currentClusterTimecode = 0;
+
+    public MatroskaContentBuffer(Channel target_channel, IContentSink content_sink)
+    {
+      this.TargetChannel = target_channel;
+      // 既存 MKVContentReader と同じく Cluster/SimpleBlock 単位でそのまま流す
+      // (FLVContentBuffer のような BufferedContentSink での再分割はしない)。
+      this.ContentSink   = content_sink;
+    }
+
+    public void OnFLVHeader(FLVFileHeader header)
+    {
+      // Matroska 経路では FLV ヘッダは使わない。
+    }
+
+    public void OnData(DataMessage msg)
+    {
+      switch (msg.PropertyName) {
+      case "@setDataFrame":
+        if (msg.Arguments.Count>=2 && (string?)msg.Arguments[0]=="onMetaData") {
+          ReadMetaData(msg.Arguments[1]);
+        }
+        break;
+      case "onMetaData":
+        if (msg.Arguments.Count>=1) {
+          ReadMetaData(msg.Arguments[0]);
+        }
+        break;
+      }
+    }
+
+    private void ReadMetaData(AMFValue meta)
+    {
+      if (meta.Type!=AMFValueType.ECMAArray && meta.Type!=AMFValueType.Object) return;
+      pixelWidth        = (int)ReadDouble(meta, "width", pixelWidth);
+      pixelHeight       = (int)ReadDouble(meta, "height", pixelHeight);
+      samplingFrequency = ReadDouble(meta, "audiosamplerate", samplingFrequency);
+      channels          = (int)ReadDouble(meta, "audiochannels", channels);
+      hasMetadata = pixelWidth>0 && pixelHeight>0;
+
+      var info = new AtomCollection();
+      info.SetChanInfoType("MKV");
+      info.SetChanInfoStreamType("video/x-matroska");
+      info.SetChanInfoStreamExt(".mkv");
+      var bitrate = 0.0;
+      var val = meta["maxBitrate"];
+      if (!AMFValue.IsNull(val)) {
+        double maxBitrate;
+        var maxBitrateStr = System.Text.RegularExpressions.Regex.Replace((string?)val ?? "", @"([\d]+)k", "$1");
+        if (double.TryParse(maxBitrateStr, out maxBitrate)) {
+          bitrate += maxBitrate;
+        }
+      }
+      else if (!AMFValue.IsNull(val = meta["videodatarate"])) {
+        bitrate += (double)val;
+      }
+      if (!AMFValue.IsNull(val = meta["audiodatarate"])) {
+        bitrate += (double)val;
+      }
+      if (bitrate>0) {
+        info.SetChanInfoBitrate((int)bitrate);
+      }
+      ContentSink.OnChannelInfo(new ChannelInfo(info));
+
+      TrySendInit();
+    }
+
+    private static double ReadDouble(AMFValue meta, string key, double fallback)
+    {
+      var val = meta[key];
+      if (AMFValue.IsNull(val)) return fallback;
+      try {
+        return (double)val;
+      }
+      catch (FormatException) {
+        return fallback;
+      }
+      catch (InvalidCastException) {
+        return fallback;
+      }
+    }
+
+    public void OnVideo(RTMPMessage msg)
+    {
+      if (!ERTMPDepacketizer.TryParseVideo(msg, out var frame)) return;
+      HandleFrame(frame);
+    }
+
+    public void OnAudio(RTMPMessage msg)
+    {
+      if (!ERTMPDepacketizer.TryParseAudio(msg, out var frame)) return;
+      HandleFrame(frame);
+    }
+
+    private void HandleFrame(DepacketizedFrame frame)
+    {
+      switch (frame.Kind) {
+      case DepacketizedFrameKind.SequenceHeader:
+        if (frame.TrackType==DepacketizedTrackType.Video) {
+          videoFourCc       = frame.FourCc;
+          videoCodecPrivate = ToArray(frame.Payload);
+        }
+        else {
+          audioFourCc       = frame.FourCc;
+          audioCodecPrivate = ToArray(frame.Payload);
+        }
+        TrySendInit();
+        break;
+
+      case DepacketizedFrameKind.CodedFrame:
+        WriteFrame(frame);
+        break;
+
+      default:
+        // SequenceEnd/Metadata/Unknown は当面破棄(remux に不要)。
+        break;
+      }
+    }
+
+    private void TrySendInit()
+    {
+      if (initSent) return;
+      if (!hasMetadata) return;
+      if (videoFourCc==null || videoCodecPrivate==null) return;
+      if (audioFourCc==null || audioCodecPrivate==null) return;
+
+      var video = new MatroskaVideoTrack {
+        FourCc       = videoFourCc,
+        CodecPrivate = videoCodecPrivate,
+        PixelWidth   = pixelWidth,
+        PixelHeight  = pixelHeight,
+      };
+      var audio = new MatroskaAudioTrack {
+        FourCc            = audioFourCc,
+        CodecPrivate      = audioCodecPrivate,
+        SamplingFrequency = samplingFrequency,
+        Channels          = channels,
+      };
+      var init = MatroskaInitBuilder.BuildInit(video, audio);
+
+      streamIndex  = TargetChannel.GenerateStreamID();
+      streamOrigin = DateTime.Now;
+      position     = 0;
+      ContentSink.OnContentHeader(
+        new Content(streamIndex, TimeSpan.Zero, position, init, PCPChanPacketContinuation.None));
+      position += init.Length;
+      initSent = true;
+    }
+
+    private void WriteFrame(DepacketizedFrame frame)
+    {
+      if (!initSent) return;
+
+      var isVideo = frame.TrackType==DepacketizedTrackType.Video;
+      // 最初の映像キーフレーム到達までは破棄(Cluster はキーフレームで開く)。
+      if (!seenFirstKeyFrame) {
+        if (!(isVideo && frame.IsKeyFrame)) return;
+        seenFirstKeyFrame = true;
+      }
+      if (!hasTimestampOrigin) {
+        timestampOrigin    = frame.Timestamp;
+        hasTimestampOrigin = true;
+      }
+      var rebased = frame.Timestamp - timestampOrigin;
+
+      using (var ms=new MemoryStream()) {
+        // 映像キーフレームごとに新しい Cluster を開く。
+        if (isVideo && frame.IsKeyFrame) {
+          currentClusterTimecode = rebased;
+          MatroskaWriter.MakeUnknownSizeHeader(Elements.Cluster).Write(ms);
+          MatroskaWriter.MakeUInt(Elements.Timecode, (ulong)Math.Max(0, currentClusterTimecode)).Write(ms);
+        }
+        var relative = (short)Math.Max(short.MinValue, Math.Min(short.MaxValue, rebased - currentClusterTimecode));
+        var track    = isVideo ? VideoTrackNumber : AudioTrackNumber;
+        MatroskaWriter.MakeSimpleBlock(track, relative, frame.IsKeyFrame, frame.Payload).Write(ms);
+
+        var bytes = ms.ToArray();
+        ContentSink.OnContent(
+          new Content(streamIndex, DateTime.Now-streamOrigin, position, bytes, PCPChanPacketContinuation.None));
+        position += bytes.Length;
+      }
+    }
+
+    private static byte[] ToArray(ArraySegment<byte> seg)
+    {
+      var arr = new byte[seg.Count];
+      if (seg.Count>0) {
+        Array.Copy(seg.Array!, seg.Offset, arr, 0, seg.Count);
+      }
+      return arr;
+    }
+  }
+}

--- a/PeerCastStation/PeerCastStation.FLV/RTMP/MatroskaContentBuffer.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/MatroskaContentBuffer.cs
@@ -23,8 +23,14 @@ namespace PeerCastStation.FLV.RTMP
   internal class MatroskaContentBuffer
     : IRTMPContentSink
   {
+    private static readonly Logger Logger = new Logger(typeof(MatroskaContentBuffer));
+
     private const ulong VideoTrackNumber = 1;
     private const ulong AudioTrackNumber = 2;
+
+    // 映像・音声の config が揃ってから、この数の CodedFrame が来ても onMetaData が
+    // 得られない場合は、CodecPrivate だけで init を組み立てる(width/height 不明のまま)。
+    private const int MetadataWaitFrames = 60;
 
     public Channel      TargetChannel { get; private set; }
     public IContentSink ContentSink   { get; private set; }
@@ -52,6 +58,14 @@ namespace PeerCastStation.FLV.RTMP
     private bool hasTimestampOrigin = false;
     private long timestampOrigin = 0;
     private long currentClusterTimecode = 0;
+
+    // §B-1: config が揃ってから metadata 無しで経過した CodedFrame 数。
+    private int  framesSinceConfigReady = 0;
+    private bool metadataFallback       = false;
+    // 1 回だけ出す警告のためのフラグ(ログのスパム防止)。
+    private bool warnedUnexpectedCts       = false;
+    private bool warnedTimecodeSaturation  = false;
+    private int  parseFailureCount         = 0;
 
     public MatroskaContentBuffer(Channel target_channel, IContentSink content_sink)
     {
@@ -91,10 +105,15 @@ namespace PeerCastStation.FLV.RTMP
       channels          = (int)ReadDouble(meta, "audiochannels", channels);
       hasMetadata = pixelWidth>0 && pixelHeight>0;
 
-      var info = new AtomCollection();
-      info.SetChanInfoType("MKV");
-      info.SetChanInfoStreamType("video/x-matroska");
-      info.SetChanInfoStreamExt(".mkv");
+      SendChannelInfo(ReadBitrate(meta));
+
+      TrySendInit();
+    }
+
+    // §D: onMetaData から bitrate(kbps)を取り出す。無ければ 0。FLVContentBuffer と同方針で
+    // maxBitrate(優先)→videodatarate、それに audiodatarate を加算する。
+    private static double ReadBitrate(AMFValue meta)
+    {
       var bitrate = 0.0;
       var val = meta["maxBitrate"];
       if (!AMFValue.IsNull(val)) {
@@ -110,12 +129,24 @@ namespace PeerCastStation.FLV.RTMP
       if (!AMFValue.IsNull(val = meta["audiodatarate"])) {
         bitrate += (double)val;
       }
+      return bitrate;
+    }
+
+    // §D: ChannelInfo(MKV)を送る。bitrate 不明(0)時は FLVContentBuffer 同様に値を捏造せず
+    //     未設定のままにする(AccessController のリレー計算に誤った値を与えないため)。
+    private void SendChannelInfo(double bitrate)
+    {
+      var info = new AtomCollection();
+      info.SetChanInfoType("MKV");
+      info.SetChanInfoStreamType("video/x-matroska");
+      info.SetChanInfoStreamExt(".mkv");
       if (bitrate>0) {
         info.SetChanInfoBitrate((int)bitrate);
       }
+      else {
+        Logger.Debug("Channel bitrate unknown (no maxBitrate/videodatarate in onMetaData)");
+      }
       ContentSink.OnChannelInfo(new ChannelInfo(info));
-
-      TrySendInit();
     }
 
     private static double ReadDouble(AMFValue meta, string key, double fallback)
@@ -133,29 +164,50 @@ namespace PeerCastStation.FLV.RTMP
       }
     }
 
+    // §B-3: パース失敗の連続を検知できるよう最初の数回だけログする(スパム防止)。
+    private const int MaxParseFailureLogs = 5;
+
     public void OnVideo(RTMPMessage msg)
     {
-      if (!ERTMPDepacketizer.TryParseVideo(msg, out var frame)) return;
+      if (!ERTMPDepacketizer.TryParseVideo(msg, out var frame)) {
+        LogParseFailure("video", msg);
+        return;
+      }
       HandleFrame(frame);
     }
 
     public void OnAudio(RTMPMessage msg)
     {
-      if (!ERTMPDepacketizer.TryParseAudio(msg, out var frame)) return;
+      if (!ERTMPDepacketizer.TryParseAudio(msg, out var frame)) {
+        LogParseFailure("audio", msg);
+        return;
+      }
       HandleFrame(frame);
+    }
+
+    private void LogParseFailure(string kind, RTMPMessage msg)
+    {
+      if (parseFailureCount>=MaxParseFailureLogs) return;
+      parseFailureCount++;
+      Logger.Debug("Failed to depacketize {0} message (len={1}){2}",
+        kind, msg.Body?.Length ?? 0,
+        parseFailureCount==MaxParseFailureLogs ? " [further parse failures suppressed]" : "");
     }
 
     private void HandleFrame(DepacketizedFrame frame)
     {
       switch (frame.Kind) {
       case DepacketizedFrameKind.SequenceHeader:
+        var newConfig = ToArray(frame.Payload);
         if (frame.TrackType==DepacketizedTrackType.Video) {
+          WarnIfConfigChanged("video", videoFourCc, videoCodecPrivate, frame.FourCc, newConfig);
           videoFourCc       = frame.FourCc;
-          videoCodecPrivate = ToArray(frame.Payload);
+          videoCodecPrivate = newConfig;
         }
         else {
+          WarnIfConfigChanged("audio", audioFourCc, audioCodecPrivate, frame.FourCc, newConfig);
           audioFourCc       = frame.FourCc;
-          audioCodecPrivate = ToArray(frame.Payload);
+          audioCodecPrivate = newConfig;
         }
         TrySendInit();
         break;
@@ -170,22 +222,55 @@ namespace PeerCastStation.FLV.RTMP
       }
     }
 
+    // §B-2: init 送出後に config(コーデック/CodecPrivate)が変わったら Info で可視化する。
+    // init は再送しない(後発参加者 resync の不変条件を壊さないため)。将来対応の足場。
+    private void WarnIfConfigChanged(string kind, string? oldFourCc, byte[]? oldConfig, string newFourCc, byte[] newConfig)
+    {
+      if (!initSent || oldConfig==null) return;
+      if (oldFourCc==newFourCc && BytesEqual(oldConfig, newConfig)) return;
+      Logger.Info(
+        "Mid-stream {0} config change ignored (init not resent): {1} -> {2}",
+        kind, oldFourCc ?? "?", newFourCc);
+    }
+
+    private static bool BytesEqual(byte[] a, byte[] b)
+    {
+      if (a.Length!=b.Length) return false;
+      for (var i=0; i<a.Length; i++) {
+        if (a[i]!=b[i]) return false;
+      }
+      return true;
+    }
+
+    private bool ConfigReady {
+      get {
+        return videoFourCc!=null && videoCodecPrivate!=null
+            && audioFourCc!=null && audioCodecPrivate!=null;
+      }
+    }
+
     private void TrySendInit()
     {
       if (initSent) return;
-      if (!hasMetadata) return;
-      if (videoFourCc==null || videoCodecPrivate==null) return;
-      if (audioFourCc==null || audioCodecPrivate==null) return;
+      if (!ConfigReady) return;
+      // §B-1: 通常は onMetaData(解像度)が揃うのを待つが、来ない配信でも
+      //       metadataFallback が立てば config だけで init を出す(width/height=0)。
+      if (!hasMetadata && !metadataFallback) return;
+
+      // metadata が無いまま init する場合は ChannelInfo(MKV)もここで送っておく。
+      if (!hasMetadata) {
+        SendChannelInfo(0.0);
+      }
 
       var video = new MatroskaVideoTrack {
-        FourCc       = videoFourCc,
-        CodecPrivate = videoCodecPrivate,
+        FourCc       = videoFourCc!,
+        CodecPrivate = videoCodecPrivate!,
         PixelWidth   = pixelWidth,
         PixelHeight  = pixelHeight,
       };
       var audio = new MatroskaAudioTrack {
-        FourCc            = audioFourCc,
-        CodecPrivate      = audioCodecPrivate,
+        FourCc            = audioFourCc!,
+        CodecPrivate      = audioCodecPrivate!,
         SamplingFrequency = samplingFrequency,
         Channels          = channels,
       };
@@ -198,23 +283,48 @@ namespace PeerCastStation.FLV.RTMP
         new Content(streamIndex, TimeSpan.Zero, position, init, PCPChanPacketContinuation.None));
       position += init.Length;
       initSent = true;
+      Logger.Info(
+        "Matroska init sent: video={0} {1}x{2} (codecPrivate={3}B), audio={4} {5}Hz {6}ch (codecPrivate={7}B){8}",
+        videoFourCc!, pixelWidth, pixelHeight, videoCodecPrivate!.Length,
+        audioFourCc!, (int)samplingFrequency, channels, audioCodecPrivate!.Length,
+        hasMetadata ? "" : " [no onMetaData; dimensions unknown]");
     }
 
     private void WriteFrame(DepacketizedFrame frame)
     {
-      if (!initSent) return;
+      if (!initSent) {
+        // §B-1: config は揃っているが onMetaData 待ちの間にフレームが来続けたら、
+        //       一定数を超えたところで config だけの init にフォールバックする。
+        if (ConfigReady && !hasMetadata && !metadataFallback) {
+          if (++framesSinceConfigReady>=MetadataWaitFrames) {
+            metadataFallback = true;
+            Logger.Debug("onMetaData not received after {0} frames; falling back to config-only init", framesSinceConfigReady);
+            TrySendInit();
+          }
+        }
+        if (!initSent) return;
+      }
 
       var isVideo = frame.TrackType==DepacketizedTrackType.Video;
       // 最初の映像キーフレーム到達までは破棄(Cluster はキーフレームで開く)。
       if (!seenFirstKeyFrame) {
         if (!(isVideo && frame.IsKeyFrame)) return;
         seenFirstKeyFrame = true;
+        Logger.Debug("First video keyframe reached; starting Matroska cluster output");
       }
+
+      // §A: 提示時刻(PTS)= DTS + CompositionTimeOffset を使う。avc1/hvc1 は B フレームで
+      //     CTS が乗る。av01 は CTS を持たない(常に 0)ので実質 DTS=PTS。
+      if (isVideo && frame.CompositionTimeOffset!=0 && frame.FourCc=="av01" && !warnedUnexpectedCts) {
+        Logger.Warn("Unexpected non-zero CTS ({0}ms) on av01 frame; av01 should not carry CompositionTime", frame.CompositionTimeOffset);
+        warnedUnexpectedCts = true;
+      }
+      var pts = frame.Timestamp + frame.CompositionTimeOffset;
       if (!hasTimestampOrigin) {
-        timestampOrigin    = frame.Timestamp;
+        timestampOrigin    = pts;
         hasTimestampOrigin = true;
       }
-      var rebased = frame.Timestamp - timestampOrigin;
+      var rebased = pts - timestampOrigin;
 
       using (var ms=new MemoryStream()) {
         // 映像キーフレームごとに新しい Cluster を開く。
@@ -223,7 +333,16 @@ namespace PeerCastStation.FLV.RTMP
           MatroskaWriter.MakeUnknownSizeHeader(Elements.Cluster).Write(ms);
           MatroskaWriter.MakeUInt(Elements.Timecode, (ulong)Math.Max(0, currentClusterTimecode)).Write(ms);
         }
-        var relative = (short)Math.Max(short.MinValue, Math.Min(short.MaxValue, rebased - currentClusterTimecode));
+        // §E: 相対 timecode は符号付き int16(±約32.7秒)。Cluster は映像キーフレームでしか
+        //     開かないため、GOP が ~32秒を超えると後半フレームが飽和して timestamp が壊れる。
+        //     Cluster 分割は「全 Cluster はキーフレームで始まる」resync 不変条件を壊すので
+        //     本質修正はせず、検知のみ警告する(通常 GOP ≤4秒では発生しない)。
+        var rawRelative = rebased - currentClusterTimecode;
+        if ((rawRelative>short.MaxValue || rawRelative<short.MinValue) && !warnedTimecodeSaturation) {
+          Logger.Warn("SimpleBlock relative timecode {0}ms exceeds int16 range; GOP may be too long (>~32s). Timestamp clamped.", rawRelative);
+          warnedTimecodeSaturation = true;
+        }
+        var relative = (short)Math.Max(short.MinValue, Math.Min(short.MaxValue, rawRelative));
         var track    = isVideo ? VideoTrackNumber : AudioTrackNumber;
         MatroskaWriter.MakeSimpleBlock(track, relative, frame.IsKeyFrame, frame.Payload).Write(ms);
 

--- a/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPContentSinkDispatcher.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPContentSinkDispatcher.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// (C) 2026 Philmist
 using System;
 using System.Collections.Generic;
 using PeerCastStation.Core;

--- a/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPContentSinkDispatcher.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPContentSinkDispatcher.cs
@@ -19,6 +19,8 @@ namespace PeerCastStation.FLV.RTMP
   internal class RTMPContentSinkDispatcher
     : IRTMPContentSink
   {
+    private static readonly Logger Logger = new Logger(typeof(RTMPContentSinkDispatcher));
+
     private const byte ExHeaderFlag = 0x80;
     // 映像が一切来ないまま(=音声のみ配信)この件数までバッファしたら旧 FLV 経路へ確定する。
     // Enhanced RTMP は配信開始直後に映像を送るため、映像があればこの閾値より前に判定が済む。
@@ -69,6 +71,9 @@ namespace PeerCastStation.FLV.RTMP
     {
       if (sink==null) {
         var enhanced = msg.Body!=null && msg.Body.Length>0 && (msg.Body[0] & ExHeaderFlag)!=0;
+        Logger.Debug("Codec dispatch: first video byte=0x{0:X2} -> {1}",
+          msg.Body!=null && msg.Body.Length>0 ? msg.Body[0] : 0,
+          enhanced ? "Matroska (Enhanced RTMP)" : "FLV (legacy)");
         Commit(enhanced
           ? (IRTMPContentSink)new MatroskaContentBuffer(targetChannel, contentSink)
           : new FLVContentBuffer(targetChannel, contentSink));
@@ -81,6 +86,7 @@ namespace PeerCastStation.FLV.RTMP
     private void FallbackIfBufferFull()
     {
       if (sink==null && buffered.Count>=FallbackToFlvAfter) {
+        Logger.Debug("No video after {0} buffered messages; falling back to FLV (audio-only stream)", buffered.Count);
         Commit(new FLVContentBuffer(targetChannel, contentSink));
       }
     }
@@ -91,6 +97,8 @@ namespace PeerCastStation.FLV.RTMP
       foreach (var action in buffered) {
         action(sink);
       }
+      Logger.Debug("Content sink committed ({0}); replayed {1} buffered message(s)",
+        chosen.GetType().Name, buffered.Count);
       buffered.Clear();
     }
   }

--- a/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPContentSinkDispatcher.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPContentSinkDispatcher.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using PeerCastStation.Core;
+
+namespace PeerCastStation.FLV.RTMP
+{
+  /// <summary>
+  /// 取り込みコーデックに応じて実 Sink を切り替える <see cref="IRTMPContentSink"/>。
+  ///
+  /// 最初の映像パケット先頭バイトが 0x80(Enhanced RTMP ExHeader)なら
+  /// <see cref="MatroskaContentBuffer"/>(Matroska へ remux)、そうでなければ
+  /// 従来の <see cref="FLVContentBuffer"/>(旧 FLV 経路はそのまま温存)を選ぶ。
+  /// 判定は connect 交渉ではなく実パケットで行う(OBS は connect fourCcList が空でも
+  /// 拡張コーデックを送ってくるため)。
+  ///
+  /// 映像パケットが来るまでにメタデータや音声が先着しうるので、判定が決まるまで受信
+  /// メッセージをバッファし、Sink 確定時に到着順で replay してから直接転送に切り替える。
+  /// </summary>
+  internal class RTMPContentSinkDispatcher
+    : IRTMPContentSink
+  {
+    private const byte ExHeaderFlag = 0x80;
+    // 映像が一切来ないまま(=音声のみ配信)この件数までバッファしたら旧 FLV 経路へ確定する。
+    // Enhanced RTMP は配信開始直後に映像を送るため、映像があればこの閾値より前に判定が済む。
+    private const int FallbackToFlvAfter = 32;
+
+    private readonly Channel      targetChannel;
+    private readonly IContentSink contentSink;
+    private readonly List<Action<IRTMPContentSink>> buffered = new List<Action<IRTMPContentSink>>();
+    private IRTMPContentSink? sink = null;
+
+    public RTMPContentSinkDispatcher(Channel target_channel, IContentSink content_sink)
+    {
+      this.targetChannel = target_channel;
+      this.contentSink   = content_sink;
+    }
+
+    public long Position {
+      get {
+        switch (sink) {
+        case FLVContentBuffer flv:     return flv.Position;
+        case MatroskaContentBuffer mkv: return mkv.Position;
+        default:                       return 0;
+        }
+      }
+    }
+
+    public void OnFLVHeader(FLVFileHeader header)
+    {
+      if (sink!=null) { sink.OnFLVHeader(header); return; }
+      buffered.Add(s => s.OnFLVHeader(header));
+    }
+
+    public void OnData(DataMessage msg)
+    {
+      if (sink!=null) { sink.OnData(msg); return; }
+      buffered.Add(s => s.OnData(msg));
+      FallbackIfBufferFull();
+    }
+
+    public void OnAudio(RTMPMessage msg)
+    {
+      if (sink!=null) { sink.OnAudio(msg); return; }
+      buffered.Add(s => s.OnAudio(msg));
+      FallbackIfBufferFull();
+    }
+
+    public void OnVideo(RTMPMessage msg)
+    {
+      if (sink==null) {
+        var enhanced = msg.Body!=null && msg.Body.Length>0 && (msg.Body[0] & ExHeaderFlag)!=0;
+        Commit(enhanced
+          ? (IRTMPContentSink)new MatroskaContentBuffer(targetChannel, contentSink)
+          : new FLVContentBuffer(targetChannel, contentSink));
+      }
+      sink!.OnVideo(msg);
+    }
+
+    // 映像が来ないまま閾値までバッファしたら音声のみ配信とみなし旧 FLV 経路へ確定する
+    // (無制限バッファの防止 + 音声のみ配信の出力を温存)。
+    private void FallbackIfBufferFull()
+    {
+      if (sink==null && buffered.Count>=FallbackToFlvAfter) {
+        Commit(new FLVContentBuffer(targetChannel, contentSink));
+      }
+    }
+
+    private void Commit(IRTMPContentSink chosen)
+    {
+      sink = chosen;
+      foreach (var action in buffered) {
+        action(sink);
+      }
+      buffered.Clear();
+    }
+  }
+}

--- a/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPSourceStream.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPSourceStream.cs
@@ -603,8 +603,15 @@ namespace PeerCastStation.FLV.RTMP
       return Task.Delay(0);
     }
 
+    private bool loggedEnhancedVideo = false;
     private Task OnVideo(RTMPMessage msg, CancellationToken cancel_token)
     {
+      // Enhanced RTMP のビデオパケットは先頭バイトの最上位ビット(IsExHeader)が立つ。
+      // M1 では到達確認のため初回のみログ出力する(remux は M2 以降)。
+      if (!loggedEnhancedVideo && msg.Body.Length>0 && (msg.Body[0] & 0x80)!=0) {
+        loggedEnhancedVideo = true;
+        Logger.Debug("Enhanced RTMP video packet (ExHeader) を検出");
+      }
       flvBuffer.OnVideo(msg);
       return Task.Delay(0);
     }
@@ -651,7 +658,9 @@ namespace PeerCastStation.FLV.RTMP
     {
       objectEncoding = ((int)msg.CommandObject["objectEncoding"])==3 ? 3 : 0;
       clientName     = (string?)msg.CommandObject["flashVer"] ?? "";
-      Logger.Debug($"connect: objectEncoding {objectEncoding}, flashVer: {clientName}");
+      var clientFourCc = EnhancedRTMP.ParseClientFourCcList(msg.CommandObject);
+      var fourCcList   = EnhancedRTMP.NegotiateVideoFourCc(clientFourCc);
+      Logger.Debug($"connect: objectEncoding {objectEncoding}, flashVer: {clientName}, fourCcList: [{String.Join(",", clientFourCc)}] -> advertising [{String.Join(",", fourCcList)}]");
       await SendMessage(stream, 2, new SetWindowSizeMessage(this.Now, 0, recvWindowSize), cancel_token).ConfigureAwait(false);
       await SendMessage(stream, 2, new SetPeerBandwidthMessage(this.Now, 0, sendWindowSize, PeerBandwidthLimitType.Hard), cancel_token).ConfigureAwait(false);
       await SendMessage(stream, 2, new UserControlMessage.StreamBeginMessage(this.Now, 0, 0), cancel_token).ConfigureAwait(false);
@@ -673,6 +682,9 @@ namespace PeerCastStation.FLV.RTMP
           { "data",           new AMF.AMFObject { { "version", "3,5,5,2004" } } },
           { "clientId",       nextClientId++ },
           { "objectEncoding", objectEncoding },
+          // Enhanced RTMP: 対応コーデックを広告して OBS の拡張コーデック配信を許可する。
+          { "capsEx",         EnhancedRTMP.CapsEx },
+          { "fourCcList",     new AMF.AMFValue(fourCcList.Select(s => new AMF.AMFValue(s))) },
         })
       );
       if (msg.TransactionId!=0) {

--- a/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPSourceStream.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPSourceStream.cs
@@ -59,12 +59,12 @@ namespace PeerCastStation.FLV.RTMP
           .Select(name => PeerCast.ContentFilters.FirstOrDefault(filter => filter.Name.ToLowerInvariant()==name.ToLowerInvariant()))
           .NotNull()
           .Aggregate(sink, (r,filter) => filter.Activate(r));
-      this.flvBuffer = new FLVContentBuffer(channel, new AsynchronousContentSink(sink));
+      this.contentSink = new RTMPContentSinkDispatcher(channel, new AsynchronousContentSink(sink));
       this.useContentBitrate = use_content_bitrate;
     }
 
     private class ConnectionStoppedExcception : ApplicationException {}
-    private FLVContentBuffer flvBuffer;
+    private RTMPContentSinkDispatcher contentSink;
     private bool useContentBitrate;
 
     public override ConnectionInfo GetConnectionInfo()
@@ -88,7 +88,7 @@ namespace PeerCastStation.FLV.RTMP
         RemoteName       = SourceUri.ToString(),
         RemoteEndPoint   = endpoint,
         RemoteHostStatus = (endpoint!=null && endpoint.Address.IsSiteLocal()) ? RemoteHostStatus.Local : RemoteHostStatus.None,
-        ContentPosition  = flvBuffer.Position,
+        ContentPosition  = contentSink.Position,
         RecvRate         = RecvRate,
         SendRate         = SendRate,
         AgentName        = clientName,
@@ -597,45 +597,21 @@ namespace PeerCastStation.FLV.RTMP
       return Task.Delay(0);
     }
 
-    private bool loggedAudioConfig = false;
     private Task OnAudio(RTMPMessage msg, CancellationToken cancel_token)
     {
-      // M2: デパケタイザで正規化し、config(SequenceHeader)到達時に判定をログ出力して検証する。
-      // 受信本体は従来どおり FLVContentBuffer へ流す(Sink 切替・Matroska 化は M4)。
-      if (ERTMPDepacketizer.TryParseAudio(msg, out var frame) &&
-          (frame.Kind==DepacketizedFrameKind.SequenceHeader || !loggedAudioConfig)) {
-        loggedAudioConfig = true;
-        LogDepacketized(frame);
-      }
-      flvBuffer.OnAudio(msg);
+      contentSink.OnAudio(msg);
       return Task.Delay(0);
     }
 
-    private bool loggedVideoConfig = false;
     private Task OnVideo(RTMPMessage msg, CancellationToken cancel_token)
     {
-      // M2: デパケタイザで正規化し、config(SequenceHeader)到達時または初回に判定をログ出力する。
-      // Enhanced RTMP(先頭バイト 0x80 の ExHeader)と旧 FLV(AVC)を同一構造体に正規化して検証する。
-      if (ERTMPDepacketizer.TryParseVideo(msg, out var frame) &&
-          (frame.Kind==DepacketizedFrameKind.SequenceHeader || !loggedVideoConfig)) {
-        loggedVideoConfig = true;
-        LogDepacketized(frame);
-      }
-      flvBuffer.OnVideo(msg);
+      contentSink.OnVideo(msg);
       return Task.Delay(0);
-    }
-
-    private void LogDepacketized(DepacketizedFrame frame)
-    {
-      Logger.Debug(
-        "Depacketized {0}: fourCC='{1}' kind={2} key={3} dts={4} cts={5} payload={6}B",
-        frame.TrackType, frame.FourCc, frame.Kind, frame.IsKeyFrame,
-        frame.Timestamp, frame.CompositionTimeOffset, frame.Payload.Count);
     }
 
     private Task OnData(DataMessage msg, CancellationToken cancel_token)
     {
-      flvBuffer.OnData(msg);
+      contentSink.OnData(msg);
       return Task.Delay(0);
     }
 

--- a/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPSourceStream.cs
+++ b/PeerCastStation/PeerCastStation.FLV/RTMP/RTMPSourceStream.cs
@@ -597,23 +597,40 @@ namespace PeerCastStation.FLV.RTMP
       return Task.Delay(0);
     }
 
+    private bool loggedAudioConfig = false;
     private Task OnAudio(RTMPMessage msg, CancellationToken cancel_token)
     {
+      // M2: デパケタイザで正規化し、config(SequenceHeader)到達時に判定をログ出力して検証する。
+      // 受信本体は従来どおり FLVContentBuffer へ流す(Sink 切替・Matroska 化は M4)。
+      if (ERTMPDepacketizer.TryParseAudio(msg, out var frame) &&
+          (frame.Kind==DepacketizedFrameKind.SequenceHeader || !loggedAudioConfig)) {
+        loggedAudioConfig = true;
+        LogDepacketized(frame);
+      }
       flvBuffer.OnAudio(msg);
       return Task.Delay(0);
     }
 
-    private bool loggedEnhancedVideo = false;
+    private bool loggedVideoConfig = false;
     private Task OnVideo(RTMPMessage msg, CancellationToken cancel_token)
     {
-      // Enhanced RTMP のビデオパケットは先頭バイトの最上位ビット(IsExHeader)が立つ。
-      // M1 では到達確認のため初回のみログ出力する(remux は M2 以降)。
-      if (!loggedEnhancedVideo && msg.Body.Length>0 && (msg.Body[0] & 0x80)!=0) {
-        loggedEnhancedVideo = true;
-        Logger.Debug("Enhanced RTMP video packet (ExHeader) を検出");
+      // M2: デパケタイザで正規化し、config(SequenceHeader)到達時または初回に判定をログ出力する。
+      // Enhanced RTMP(先頭バイト 0x80 の ExHeader)と旧 FLV(AVC)を同一構造体に正規化して検証する。
+      if (ERTMPDepacketizer.TryParseVideo(msg, out var frame) &&
+          (frame.Kind==DepacketizedFrameKind.SequenceHeader || !loggedVideoConfig)) {
+        loggedVideoConfig = true;
+        LogDepacketized(frame);
       }
       flvBuffer.OnVideo(msg);
       return Task.Delay(0);
+    }
+
+    private void LogDepacketized(DepacketizedFrame frame)
+    {
+      Logger.Debug(
+        "Depacketized {0}: fourCC='{1}' kind={2} key={3} dts={4} cts={5} payload={6}B",
+        frame.TrackType, frame.FourCc, frame.Kind, frame.IsKeyFrame,
+        frame.Timestamp, frame.CompositionTimeOffset, frame.Payload.Count);
     }
 
     private Task OnData(DataMessage msg, CancellationToken cancel_token)

--- a/PeerCastStation/PeerCastStation.MKV/MKVContentReader.cs
+++ b/PeerCastStation/PeerCastStation.MKV/MKVContentReader.cs
@@ -58,6 +58,23 @@ namespace PeerCastStation.MKV
       throw new ArgumentOutOfRangeException(nameof(value));
     }
 
+    /// <summary>
+    /// "unknown size"(全ビット 1)の VInt を生成する。ライブ mux で全長未確定の
+    /// Segment を開くのに使う。読み戻すと IsUnknown==true になる。
+    /// </summary>
+    public static VInt Unknown(int len)
+    {
+      if (len<1 || len>8) throw new ArgumentOutOfRangeException(nameof(len));
+      long value = (1L<<(7*len)) - 1;       //値部の 7*len ビットが全 1
+      long encoded = (1L<<(7*len)) | value; //長さマーカー込みで len バイト全 0xFF
+      var bin = new byte[len];
+      for (int i=len-1; i>=0; i--) {
+        bin[i] = (byte)(encoded & 0xFF);
+        encoded >>= 8;
+      }
+      return new VInt(value, bin);
+    }
+
     public static async Task<VInt> ReadUIntAsync(Stream s, CancellationToken cancel_token)
     {
       int first = await s.ReadByteAsync().ConfigureAwait(false);
@@ -233,6 +250,20 @@ namespace PeerCastStation.MKV
     public static readonly byte[] Chapters      = { 0x10,0x43,0xA7,0x70 };
     public static readonly byte[] Tags          = { 0x12,0x54,0xC3,0x67 };
     public static readonly byte[] TimecodeScale = { 0x2A,0xD1,0xB1 };
+    public static readonly byte[] MuxingApp     = { 0x4D,0x80 };
+    public static readonly byte[] WritingApp    = { 0x57,0x41 };
+    public static readonly byte[] TrackEntry    = { 0xAE };
+    public static readonly byte[] TrackNumber   = { 0xD7 };
+    public static readonly byte[] TrackUID      = { 0x73,0xC5 };
+    public static readonly byte[] TrackType     = { 0x83 };
+    public static readonly byte[] CodecID       = { 0x86 };
+    public static readonly byte[] CodecPrivate  = { 0x63,0xA2 };
+    public static readonly byte[] Video         = { 0xE0 };
+    public static readonly byte[] PixelWidth    = { 0xB0 };
+    public static readonly byte[] PixelHeight   = { 0xBA };
+    public static readonly byte[] Audio         = { 0xE1 };
+    public static readonly byte[] SamplingFrequency = { 0xB5 };
+    public static readonly byte[] Channels      = { 0x9F };
     public static readonly byte[] BlockGroup    = { 0xA0 };
     public static readonly byte[] SimpleBlock   = { 0xA3 };
     public static readonly byte[] Timecode      = { 0xE7 };

--- a/PeerCastStation/PeerCastStation.MKV/MKVContentReader.cs
+++ b/PeerCastStation/PeerCastStation.MKV/MKVContentReader.cs
@@ -249,7 +249,7 @@ namespace PeerCastStation.MKV
     public static readonly byte[] Attachments   = { 0x19,0x41,0xA4,0x69 };
     public static readonly byte[] Chapters      = { 0x10,0x43,0xA7,0x70 };
     public static readonly byte[] Tags          = { 0x12,0x54,0xC3,0x67 };
-    public static readonly byte[] TimecodeScale = { 0x2A,0xD1,0xB1 };
+    public static readonly byte[] TimecodeScale = { 0x2A,0xD7,0xB1 };
     public static readonly byte[] MuxingApp     = { 0x4D,0x80 };
     public static readonly byte[] WritingApp    = { 0x57,0x41 };
     public static readonly byte[] TrackEntry    = { 0xAE };

--- a/PeerCastStation/PeerCastStation.MKV/MKVContentReader.cs
+++ b/PeerCastStation/PeerCastStation.MKV/MKVContentReader.cs
@@ -35,6 +35,29 @@ namespace PeerCastStation.MKV
       return this.Binary.SequenceEqual(bin);
     }
 
+    /// <summary>
+    /// 要素サイズ用の VInt を生成する。ReadUInt と対称で、生成した Binary を
+    /// 読み戻すと Value==value になる。最小バイト長を選び、全ビット 1 の
+    /// "unknown size" と衝突する値は 1 バイト繰り上げる。
+    /// </summary>
+    public static VInt FromSize(long value)
+    {
+      if (value<0) throw new ArgumentOutOfRangeException(nameof(value));
+      for (int len=1; len<=8; len++) {
+        long max = (1L<<(7*len)) - 2; //全ビット1(=-1相当)は unknown size 用に予約
+        if (value<=max) {
+          long encoded = (1L<<(7*len)) | value;
+          var bin = new byte[len];
+          for (int i=len-1; i>=0; i--) {
+            bin[i] = (byte)(encoded & 0xFF);
+            encoded >>= 8;
+          }
+          return new VInt(value, bin);
+        }
+      }
+      throw new ArgumentOutOfRangeException(nameof(value));
+    }
+
     public static async Task<VInt> ReadUIntAsync(Stream s, CancellationToken cancel_token)
     {
       int first = await s.ReadByteAsync().ConfigureAwait(false);

--- a/PeerCastStation/PeerCastStation.MKV/MatroskaInitBuilder.cs
+++ b/PeerCastStation/PeerCastStation.MKV/MatroskaInitBuilder.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// (C) 2026 Philmist
 using System;
 using System.IO;
 

--- a/PeerCastStation/PeerCastStation.MKV/MatroskaInitBuilder.cs
+++ b/PeerCastStation/PeerCastStation.MKV/MatroskaInitBuilder.cs
@@ -1,0 +1,116 @@
+using System;
+using System.IO;
+
+namespace PeerCastStation.MKV
+{
+  /// <summary>映像トラックの中立記述(コーデック非依存)。</summary>
+  internal struct MatroskaVideoTrack
+  {
+    /// <summary>実パケットの FourCc("av01"/"hvc1"/"avc1")。</summary>
+    public string FourCc;
+    /// <summary>SequenceHeader のペイロード(av1C/hvcC/avcC)をそのまま CodecPrivate に入れる。</summary>
+    public byte[] CodecPrivate;
+    public int PixelWidth;
+    public int PixelHeight;
+  }
+
+  /// <summary>音声トラックの中立記述(コーデック非依存)。</summary>
+  internal struct MatroskaAudioTrack
+  {
+    /// <summary>実パケットの FourCc("mp4a")。</summary>
+    public string FourCc;
+    /// <summary>AudioSpecificConfig をそのまま CodecPrivate に入れる。</summary>
+    public byte[] CodecPrivate;
+    public double SamplingFrequency;
+    public int Channels;
+  }
+
+  /// <summary>
+  /// Enhanced RTMP / 旧 FLV から取り出したコーデック config とメタ情報から、
+  /// Matroska の init 領域(EBML Header → Segment 開始 → Info → Tracks)の
+  /// バイト列を組み立てる。Cluster は含めない(ライブ出力は M4)。
+  /// 単一映像 + 単一音声トラック前提(capsEx=0、multitrack 非対応)。
+  /// CodecPrivate は中身を解析せず透過コピーする(M2 で av1C=20B / ASC=5B を確認)。
+  /// </summary>
+  internal static class MatroskaInitBuilder
+  {
+    public const ulong DefaultTimecodeScale = 1000000; //1ms(RTMP の ms タイムスタンプと素直に対応)
+    public const string WriterName = "PeerCastStation";
+
+    private const ulong VideoTrackNumber = 1;
+    private const ulong AudioTrackNumber = 2;
+    private const ulong TrackTypeVideo = 1;
+    private const ulong TrackTypeAudio = 2;
+
+    /// <summary>FourCc を Matroska の CodecID 文字列へ対応付ける。</summary>
+    public static string FourCcToCodecId(string fourCc)
+    {
+      switch (fourCc) {
+      case "av01": return "V_AV1";
+      case "hvc1": return "V_MPEGH/ISO/HEVC";
+      case "avc1": return "V_MPEG4/ISO/AVC";
+      case "mp4a": return "A_AAC";
+      default:
+        throw new ArgumentException($"未対応の FourCc: {fourCc}", nameof(fourCc));
+      }
+    }
+
+    /// <summary>映像 + 音声トラックから init 領域バイト列を組み立てる。</summary>
+    public static byte[] BuildInit(MatroskaVideoTrack video, MatroskaAudioTrack audio)
+    {
+      var ebml = MatroskaWriter.MakeMaster(Elements.EBML,
+        MatroskaWriter.MakeUInt(Elements.EBMLVersion, 1),
+        MatroskaWriter.MakeUInt(Elements.EBMLReadVersion, 1),
+        MatroskaWriter.MakeUInt(Elements.EBMLMaxIDLength, 4),
+        MatroskaWriter.MakeUInt(Elements.EBMLMaxSizeLength, 8),
+        MatroskaWriter.MakeString(Elements.DocType, "matroska"),
+        MatroskaWriter.MakeUInt(Elements.DocTypeVersion, 4),     //AV1/HEVC を含めるため 4
+        MatroskaWriter.MakeUInt(Elements.DocTypeReadVersion, 2));
+
+      var info = MatroskaWriter.MakeMaster(Elements.Info,
+        MatroskaWriter.MakeUInt(Elements.TimecodeScale, DefaultTimecodeScale),
+        MatroskaWriter.MakeString(Elements.MuxingApp, WriterName),
+        MatroskaWriter.MakeString(Elements.WritingApp, WriterName));
+
+      var tracks = MatroskaWriter.MakeMaster(Elements.Tracks,
+        MakeVideoTrackEntry(video),
+        MakeAudioTrackEntry(audio));
+
+      var segmentHeader = MatroskaWriter.MakeUnknownSizeHeader(Elements.Segment);
+
+      using (var ms=new MemoryStream()) {
+        ebml.Write(ms);
+        segmentHeader.Write(ms); //Segment は開いたまま(unknown-size)。以降は Segment の子。
+        info.Write(ms);
+        tracks.Write(ms);
+        return ms.ToArray();
+      }
+    }
+
+    private static Element MakeVideoTrackEntry(MatroskaVideoTrack video)
+    {
+      return MatroskaWriter.MakeMaster(Elements.TrackEntry,
+        MatroskaWriter.MakeUInt(Elements.TrackNumber, VideoTrackNumber),
+        MatroskaWriter.MakeUInt(Elements.TrackUID, VideoTrackNumber),
+        MatroskaWriter.MakeUInt(Elements.TrackType, TrackTypeVideo),
+        MatroskaWriter.MakeString(Elements.CodecID, FourCcToCodecId(video.FourCc)),
+        MatroskaWriter.MakeBinary(Elements.CodecPrivate, video.CodecPrivate),
+        MatroskaWriter.MakeMaster(Elements.Video,
+          MatroskaWriter.MakeUInt(Elements.PixelWidth, (ulong)video.PixelWidth),
+          MatroskaWriter.MakeUInt(Elements.PixelHeight, (ulong)video.PixelHeight)));
+    }
+
+    private static Element MakeAudioTrackEntry(MatroskaAudioTrack audio)
+    {
+      return MatroskaWriter.MakeMaster(Elements.TrackEntry,
+        MatroskaWriter.MakeUInt(Elements.TrackNumber, AudioTrackNumber),
+        MatroskaWriter.MakeUInt(Elements.TrackUID, AudioTrackNumber),
+        MatroskaWriter.MakeUInt(Elements.TrackType, TrackTypeAudio),
+        MatroskaWriter.MakeString(Elements.CodecID, FourCcToCodecId(audio.FourCc)),
+        MatroskaWriter.MakeBinary(Elements.CodecPrivate, audio.CodecPrivate),
+        MatroskaWriter.MakeMaster(Elements.Audio,
+          MatroskaWriter.MakeFloat(Elements.SamplingFrequency, audio.SamplingFrequency),
+          MatroskaWriter.MakeUInt(Elements.Channels, (ulong)audio.Channels)));
+    }
+  }
+}

--- a/PeerCastStation/PeerCastStation.MKV/MatroskaInitBuilder.cs
+++ b/PeerCastStation/PeerCastStation.MKV/MatroskaInitBuilder.cs
@@ -28,9 +28,9 @@ namespace PeerCastStation.MKV
   /// <summary>
   /// Enhanced RTMP / 旧 FLV から取り出したコーデック config とメタ情報から、
   /// Matroska の init 領域(EBML Header → Segment 開始 → Info → Tracks)の
-  /// バイト列を組み立てる。Cluster は含めない(ライブ出力は M4)。
+  /// バイト列を組み立てる。Clusterは含めない。
   /// 単一映像 + 単一音声トラック前提(capsEx=0、multitrack 非対応)。
-  /// CodecPrivate は中身を解析せず透過コピーする(M2 で av1C=20B / ASC=5B を確認)。
+  /// CodecPrivate は中身を解析せず透過コピーする(av1C=20B / ASC=5Bを確認)。
   /// </summary>
   internal static class MatroskaInitBuilder
   {

--- a/PeerCastStation/PeerCastStation.MKV/MatroskaWriter.cs
+++ b/PeerCastStation/PeerCastStation.MKV/MatroskaWriter.cs
@@ -1,0 +1,83 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace PeerCastStation.MKV
+{
+  /// <summary>
+  /// EBML/Matroska 要素を組み立てる writer プリミティブ。
+  /// MKVContentReader のリーダー(VInt/ElementHeader/Element)と対称に動作し、
+  /// 生成した Element を既存リーダーで読み戻すと元の値・バイト列に一致する。
+  /// 要素 ID は Elements の既知バイト列(長さマーカー込み)をそのまま使う。
+  /// </summary>
+  internal static class MatroskaWriter
+  {
+    /// <summary>ID バイト列を VInt としてラップする(書き出しでは Binary のみ使用)。</summary>
+    private static VInt IdVInt(byte[] id)
+    {
+      return new VInt(0, id);
+    }
+
+    /// <summary>ID + サイズ VInt + payload からなるリーフ/任意要素を作る。</summary>
+    public static Element MakeElement(byte[] id, byte[] data)
+    {
+      return new Element(new ElementHeader(IdVInt(id), VInt.FromSize(data.LongLength)), data);
+    }
+
+    /// <summary>子要素を連結し、その合計バイト長をサイズに持つ master 要素を作る。</summary>
+    public static Element MakeMaster(byte[] id, params Element[] children)
+    {
+      using (var ms=new MemoryStream()) {
+        foreach (var c in children) {
+          c.Write(ms);
+        }
+        return MakeElement(id, ms.ToArray());
+      }
+    }
+
+    /// <summary>符号なし整数要素(big-endian, 最小バイト長)。</summary>
+    public static Element MakeUInt(byte[] id, ulong value)
+    {
+      return MakeElement(id, MinimalUIntBytes(value));
+    }
+
+    /// <summary>UTF-8 文字列要素。</summary>
+    public static Element MakeString(byte[] id, string value)
+    {
+      return MakeElement(id, Encoding.UTF8.GetBytes(value));
+    }
+
+    /// <summary>バイナリ要素(CodecPrivate など)。</summary>
+    public static Element MakeBinary(byte[] id, byte[] value)
+    {
+      return MakeElement(id, value);
+    }
+
+    /// <summary>倍精度浮動小数要素(8 バイト IEEE754, big-endian)。</summary>
+    public static Element MakeFloat(byte[] id, double value)
+    {
+      var bin = BitConverter.GetBytes(value);
+      if (BitConverter.IsLittleEndian) {
+        Array.Reverse(bin);
+      }
+      return MakeElement(id, bin);
+    }
+
+    /// <summary>値を表せる最小バイト数の big-endian 表現(0 は 1 バイト)。</summary>
+    private static byte[] MinimalUIntBytes(ulong value)
+    {
+      int len = 1;
+      var t = value >> 8;
+      while (t!=0) {
+        len++;
+        t >>= 8;
+      }
+      var bin = new byte[len];
+      for (int i=len-1; i>=0; i--) {
+        bin[i] = (byte)(value & 0xFF);
+        value >>= 8;
+      }
+      return bin;
+    }
+  }
+}

--- a/PeerCastStation/PeerCastStation.MKV/MatroskaWriter.cs
+++ b/PeerCastStation/PeerCastStation.MKV/MatroskaWriter.cs
@@ -35,6 +35,16 @@ namespace PeerCastStation.MKV
       }
     }
 
+    /// <summary>
+    /// unknown-size(全ビット 1)で開く master 要素のヘッダ(ID + サイズ VInt のみ)。
+    /// ライブ mux で全長未確定の Segment を開くのに使う。子要素はこのヘッダの後ろに
+    /// 連続して書き出す。リーダーは Element.NoData として読む。
+    /// </summary>
+    public static ElementHeader MakeUnknownSizeHeader(byte[] id)
+    {
+      return new ElementHeader(IdVInt(id), VInt.Unknown(1));
+    }
+
     /// <summary>符号なし整数要素(big-endian, 最小バイト長)。</summary>
     public static Element MakeUInt(byte[] id, ulong value)
     {

--- a/PeerCastStation/PeerCastStation.MKV/MatroskaWriter.cs
+++ b/PeerCastStation/PeerCastStation.MKV/MatroskaWriter.cs
@@ -51,6 +51,28 @@ namespace PeerCastStation.MKV
       return MakeElement(id, MinimalUIntBytes(value));
     }
 
+    /// <summary>
+    /// SimpleBlock(0xA3)要素を作る。ライブ mux のフレーム 1 つ分。
+    /// ボディは [トラック番号 VInt][相対 timecode int16 big-endian][フラグ][payload]。
+    /// 相対 timecode は所属 Cluster の Timecode からの差(ミリ秒, 符号付き int16)。
+    /// keyframe なら最上位ビット(0x80)を立てる。lacing は使わない。
+    /// payload は中身を解析せず透過コピーする(NAL/OBU をそのまま入れる)。
+    /// </summary>
+    public static Element MakeSimpleBlock(ulong trackNumber, short relativeTimecode, bool isKeyFrame, ArraySegment<byte> payload)
+    {
+      var track = VInt.FromSize((long)trackNumber).Binary;
+      using (var ms=new MemoryStream()) {
+        ms.Write(track, 0, track.Length);
+        ms.WriteByte((byte)((relativeTimecode>>8) & 0xFF));
+        ms.WriteByte((byte)(relativeTimecode & 0xFF));
+        ms.WriteByte((byte)(isKeyFrame ? 0x80 : 0x00));
+        if (payload.Count>0) {
+          ms.Write(payload.Array!, payload.Offset, payload.Count);
+        }
+        return MakeElement(Elements.SimpleBlock, ms.ToArray());
+      }
+    }
+
     /// <summary>UTF-8 文字列要素。</summary>
     public static Element MakeString(byte[] id, string value)
     {

--- a/PeerCastStation/PeerCastStation.MKV/MatroskaWriter.cs
+++ b/PeerCastStation/PeerCastStation.MKV/MatroskaWriter.cs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// (C) 2026 Philmist
 using System;
 using System.IO;
 using System.Text;

--- a/PeerCastStation/PeerCastStation.MKV/Properties/AssemblyInfo.cs
+++ b/PeerCastStation/PeerCastStation.MKV/Properties/AssemblyInfo.cs
@@ -8,6 +8,9 @@ using System.Runtime.InteropServices;
 // テストプロジェクト(同一 snk で署名)から internal の VInt/Element 等へアクセスするための friend 宣言。
 // 署名アセンブリ間なので full public key の指定が必須。
 [assembly: InternalsVisibleTo("PeerCastStation.Test, PublicKey=00240000048000009400000006020000002400005253413100040000010001003b4def7d493cd15e2de42ec2a7edc4f90390af0e8c535e8494b2b4b99e6b95b0c1a6176ee25750801d0698c07dd70f6e131b46e1196e256d5c36d8dd510f73bb5efa555d75bd23d8a93f5f7dbf272876789a3c5f83b8e01914f3e5926b79b61c385a93ef654be66d4ee5f3d485f0d3d94ceecdd96cafc377f7dbf0995b9a5dba")]
+// MatroskaContentBuffer(M4)から MatroskaInitBuilder/MatroskaWriter/Elements 等の internal へアクセスするための friend 宣言。
+// FLV は同一 PeerCastStation.snk で署名されるため Test と同じ full public key を使う。
+[assembly: InternalsVisibleTo("PeerCastStation.FLV, PublicKey=00240000048000009400000006020000002400005253413100040000010001003b4def7d493cd15e2de42ec2a7edc4f90390af0e8c535e8494b2b4b99e6b95b0c1a6176ee25750801d0698c07dd70f6e131b46e1196e256d5c36d8dd510f73bb5efa555d75bd23d8a93f5f7dbf272876789a3c5f83b8e01914f3e5926b79b61c385a93ef654be66d4ee5f3d485f0d3d94ceecdd96cafc377f7dbf0995b9a5dba")]
 
 [assembly: AssemblyTitle("PeerCastStation.MKV")]
 [assembly: AssemblyDescription("")]

--- a/PeerCastStation/PeerCastStation.MKV/Properties/AssemblyInfo.cs
+++ b/PeerCastStation/PeerCastStation.MKV/Properties/AssemblyInfo.cs
@@ -5,6 +5,10 @@ using System.Runtime.InteropServices;
 // アセンブリに関する一般情報は以下の属性セットをとおして制御されます。
 // アセンブリに関連付けられている情報を変更するには、
 // これらの属性値を変更してください。
+// テストプロジェクト(同一 snk で署名)から internal の VInt/Element 等へアクセスするための friend 宣言。
+// 署名アセンブリ間なので full public key の指定が必須。
+[assembly: InternalsVisibleTo("PeerCastStation.Test, PublicKey=00240000048000009400000006020000002400005253413100040000010001003b4def7d493cd15e2de42ec2a7edc4f90390af0e8c535e8494b2b4b99e6b95b0c1a6176ee25750801d0698c07dd70f6e131b46e1196e256d5c36d8dd510f73bb5efa555d75bd23d8a93f5f7dbf272876789a3c5f83b8e01914f3e5926b79b61c385a93ef654be66d4ee5f3d485f0d3d94ceecdd96cafc377f7dbf0995b9a5dba")]
+
 [assembly: AssemblyTitle("PeerCastStation.MKV")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]

--- a/PeerCastStation/PeerCastStation.MKV/Properties/AssemblyInfo.cs
+++ b/PeerCastStation/PeerCastStation.MKV/Properties/AssemblyInfo.cs
@@ -5,10 +5,11 @@ using System.Runtime.InteropServices;
 // アセンブリに関する一般情報は以下の属性セットをとおして制御されます。
 // アセンブリに関連付けられている情報を変更するには、
 // これらの属性値を変更してください。
+
 // テストプロジェクト(同一 snk で署名)から internal の VInt/Element 等へアクセスするための friend 宣言。
 // 署名アセンブリ間なので full public key の指定が必須。
 [assembly: InternalsVisibleTo("PeerCastStation.Test, PublicKey=00240000048000009400000006020000002400005253413100040000010001003b4def7d493cd15e2de42ec2a7edc4f90390af0e8c535e8494b2b4b99e6b95b0c1a6176ee25750801d0698c07dd70f6e131b46e1196e256d5c36d8dd510f73bb5efa555d75bd23d8a93f5f7dbf272876789a3c5f83b8e01914f3e5926b79b61c385a93ef654be66d4ee5f3d485f0d3d94ceecdd96cafc377f7dbf0995b9a5dba")]
-// MatroskaContentBuffer(M4)から MatroskaInitBuilder/MatroskaWriter/Elements 等の internal へアクセスするための friend 宣言。
+// MatroskaContentBufferから MatroskaInitBuilder/MatroskaWriter/Elements 等の internal へアクセスするための friend 宣言。
 // FLV は同一 PeerCastStation.snk で署名されるため Test と同じ full public key を使う。
 [assembly: InternalsVisibleTo("PeerCastStation.FLV, PublicKey=00240000048000009400000006020000002400005253413100040000010001003b4def7d493cd15e2de42ec2a7edc4f90390af0e8c535e8494b2b4b99e6b95b0c1a6176ee25750801d0698c07dd70f6e131b46e1196e256d5c36d8dd510f73bb5efa555d75bd23d8a93f5f7dbf272876789a3c5f83b8e01914f3e5926b79b61c385a93ef654be66d4ee5f3d485f0d3d94ceecdd96cafc377f7dbf0995b9a5dba")]
 

--- a/PeerCastStation/PeerCastStation.Test/MKVTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/MKVTests.fs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// (C) 2026 Philmist
 module MKVTests
 
 open System.IO

--- a/PeerCastStation/PeerCastStation.Test/MKVTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/MKVTests.fs
@@ -132,6 +132,34 @@ let ``FourCcToCodecId は未対応 FourCc を拒否する`` () =
         MatroskaInitBuilder.FourCcToCodecId("xxxx") |> ignore)
     |> ignore
 
+// MakeSimpleBlock: [トラック VInt][相対 timecode int16 BE][フラグ][payload] を組み立て、
+// SimpleBlock(0xA3)要素として読み戻せる。track1→0x81, track2→0x82。
+[<Fact>]
+let ``MakeSimpleBlock は track1 keyframe を正しく組み立てる`` () =
+    let payload = System.ArraySegment<byte>([| 0xAAuy; 0xBBuy |])
+    let elt = MatroskaWriter.MakeSimpleBlock(1UL, 0s, true, payload)
+    use ms = new MemoryStream(elt.ToArray())
+    let mutable h = ElementHeader.Read(ms)
+    Assert.True(h.ID.BinaryEquals(Elements.SimpleBlock))
+    let body = Element.ReadBody(&h, ms)
+    // 0x81(track1 VInt), 0x00 0x00(tc=0), 0x80(keyframe), payload
+    Assert.Equal<byte[]>([| 0x81uy; 0x00uy; 0x00uy; 0x80uy; 0xAAuy; 0xBBuy |], body.Data)
+
+[<Fact>]
+let ``MakeSimpleBlock は track2 非keyframe で負の相対timecodeを符号化する`` () =
+    let payload = System.ArraySegment<byte>([| 0xCCuy |])
+    let elt = MatroskaWriter.MakeSimpleBlock(2UL, -2s, false, payload)
+    use ms = new MemoryStream(elt.ToArray())
+    let mutable h = ElementHeader.Read(ms)
+    let body = Element.ReadBody(&h, ms)
+    // 0x82(track2), 0xFF 0xFE(tc=-2), 0x00(非keyframe), payload
+    Assert.Equal<byte[]>([| 0x82uy; 0xFFuy; 0xFEuy; 0x00uy; 0xCCuy |], body.Data)
+
+[<Fact>]
+let ``MakeSimpleBlock は空payloadでもヘッダ4byteを保つ`` () =
+    let elt = MatroskaWriter.MakeSimpleBlock(1UL, 100s, true, System.ArraySegment<byte>([||]))
+    Assert.Equal<byte[]>([| 0x81uy; 0x00uy; 0x64uy; 0x80uy |], elt.Data)
+
 // init 領域内の特定 master 要素を読み出すヘルパ(トップレベルを線形走査)。
 let private readTopLevel (init: byte[]) (id: byte[]) =
     use ms = new MemoryStream(init)

--- a/PeerCastStation/PeerCastStation.Test/MKVTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/MKVTests.fs
@@ -97,3 +97,157 @@ let ``MakeUInt は最小バイト長で符号化する`` (value: int, expectedLe
     let elt = MatroskaWriter.MakeUInt(Elements.TimecodeScale, uint64 value)
     Assert.Equal(expectedLen, elt.Data.Length)
     Assert.Equal(int64 value, Element.ReadUInt(new MemoryStream(elt.Data), elt.Data.LongLength))
+
+// VInt.Unknown: 全ビット1で生成し、読み戻すと IsUnknown==true になる。
+// len は実用範囲(Segment は len=1)。len*7>=32 では既存 IsUnknown の int シフト
+// 制約に触れるため対象外とする。
+[<Theory>]
+[<InlineData(1)>]
+[<InlineData(2)>]
+[<InlineData(3)>]
+[<InlineData(4)>]
+let ``VInt.Unknown は全ビット1で IsUnknown になる`` (len: int) =
+    let v = VInt.Unknown(len)
+    Assert.Equal(len, v.Length)
+    // EBML の unknown-size は値ビットが全 1(長さマーカーは別)。最終バイトは 0xFF。
+    Assert.Equal(0xFFuy, v.Binary.[len - 1])
+    Assert.True(v.IsUnknown)
+    use ms = new MemoryStream(v.Binary)
+    let read = VInt.ReadUInt(ms)
+    Assert.Equal(len, read.Length)
+    Assert.True(read.IsUnknown)
+
+// FourCc → CodecID マッピングを網羅。
+[<Theory>]
+[<InlineData("av01", "V_AV1")>]
+[<InlineData("hvc1", "V_MPEGH/ISO/HEVC")>]
+[<InlineData("avc1", "V_MPEG4/ISO/AVC")>]
+[<InlineData("mp4a", "A_AAC")>]
+let ``FourCcToCodecId は既知コーデックを対応付ける`` (fourCc: string, codecId: string) =
+    Assert.Equal(codecId, MatroskaInitBuilder.FourCcToCodecId(fourCc))
+
+[<Fact>]
+let ``FourCcToCodecId は未対応 FourCc を拒否する`` () =
+    Assert.Throws<System.ArgumentException>(fun () ->
+        MatroskaInitBuilder.FourCcToCodecId("xxxx") |> ignore)
+    |> ignore
+
+// init 領域内の特定 master 要素を読み出すヘルパ(トップレベルを線形走査)。
+let private readTopLevel (init: byte[]) (id: byte[]) =
+    use ms = new MemoryStream(init)
+    let mutable result = None
+    while result.IsNone && ms.Position < ms.Length do
+        let mutable h = ElementHeader.Read(ms)
+        if h.ID.BinaryEquals(id) then
+            result <- Some(Element.ReadBody(&h, ms))
+        elif h.Size.IsUnknown then
+            () // Segment など unknown-size はスキップせず中身を続けて走査
+        else
+            Element.ReadBody(&h, ms) |> ignore
+    result.Value
+
+// master の子要素を辿って指定 ID の最初の子を返す。
+let private childOf (master: Element) (id: byte[]) =
+    use ms = new MemoryStream(master.Data)
+    let mutable result = None
+    while result.IsNone && ms.Position < ms.Length do
+        let mutable h = ElementHeader.Read(ms)
+        let body = Element.ReadBody(&h, ms)
+        if h.ID.BinaryEquals(id) then result <- Some(body)
+    result.Value
+
+let private sampleVideo : MatroskaVideoTrack =
+    let mutable v = MatroskaVideoTrack()
+    v.FourCc <- "av01"
+    v.CodecPrivate <- [| 0x81uy; 0x05uy; 0x0Cuy; 0x00uy |] // av1C 風ダミー
+    v.PixelWidth <- 1920
+    v.PixelHeight <- 1080
+    v
+
+let private sampleAudio : MatroskaAudioTrack =
+    let mutable a = MatroskaAudioTrack()
+    a.FourCc <- "mp4a"
+    a.CodecPrivate <- [| 0x11uy; 0x90uy |] // AudioSpecificConfig 風ダミー
+    a.SamplingFrequency <- 48000.0
+    a.Channels <- 2
+    a
+
+// init 領域は EBML→Segment(unknown)→Info→Tracks の順で並ぶ。
+[<Fact>]
+let ``BuildInit は EBML Segment Info Tracks の順で出力する`` () =
+    let init = MatroskaInitBuilder.BuildInit(sampleVideo, sampleAudio)
+    use ms = new MemoryStream(init)
+
+    let mutable hEbml = ElementHeader.Read(ms)
+    Assert.True(hEbml.ID.BinaryEquals(Elements.EBML))
+    Element.ReadBody(&hEbml, ms) |> ignore
+
+    let hSeg = ElementHeader.Read(ms)
+    Assert.True(hSeg.ID.BinaryEquals(Elements.Segment))
+    Assert.True(hSeg.Size.IsUnknown) // ライブ mux ゆえ unknown-size
+
+    let hInfo = ElementHeader.Read(ms)
+    Assert.True(hInfo.ID.BinaryEquals(Elements.Info))
+    ms.Seek(hInfo.Size.Value, SeekOrigin.Current) |> ignore
+
+    let hTracks = ElementHeader.Read(ms)
+    Assert.True(hTracks.ID.BinaryEquals(Elements.Tracks))
+
+// EBML ヘッダの DocType が matroska であること。
+[<Fact>]
+let ``BuildInit の DocType は matroska`` () =
+    let init = MatroskaInitBuilder.BuildInit(sampleVideo, sampleAudio)
+    let ebml = readTopLevel init Elements.EBML
+    let docType = childOf ebml Elements.DocType
+    Assert.Equal("matroska", Encoding.UTF8.GetString(docType.Data))
+
+// Info の TimecodeScale が 1ms(1000000ns)。
+[<Fact>]
+let ``BuildInit の TimecodeScale は 1000000`` () =
+    let init = MatroskaInitBuilder.BuildInit(sampleVideo, sampleAudio)
+    let info = readTopLevel init Elements.Info
+    let ts = childOf info Elements.TimecodeScale
+    Assert.Equal(1000000L, Element.ReadUInt(new MemoryStream(ts.Data), ts.Data.LongLength))
+
+// 映像トラックの CodecID/CodecPrivate/解像度を検証。
+[<Fact>]
+let ``BuildInit の映像トラックを読み戻せる`` () =
+    let init = MatroskaInitBuilder.BuildInit(sampleVideo, sampleAudio)
+    let tracks = readTopLevel init Elements.Tracks
+    // 先頭の TrackEntry が映像(TrackType=1)
+    let video = childOf tracks Elements.TrackEntry
+    let trackType = childOf video Elements.TrackType
+    Assert.Equal(1L, Element.ReadUInt(new MemoryStream(trackType.Data), trackType.Data.LongLength))
+    let codecId = childOf video Elements.CodecID
+    Assert.Equal("V_AV1", Encoding.UTF8.GetString(codecId.Data))
+    let codecPrivate = childOf video Elements.CodecPrivate
+    Assert.Equal<byte[]>(sampleVideo.CodecPrivate, codecPrivate.Data) // 透過コピー
+    let vsettings = childOf video Elements.Video
+    let width = childOf vsettings Elements.PixelWidth
+    Assert.Equal(1920L, Element.ReadUInt(new MemoryStream(width.Data), width.Data.LongLength))
+    let height = childOf vsettings Elements.PixelHeight
+    Assert.Equal(1080L, Element.ReadUInt(new MemoryStream(height.Data), height.Data.LongLength))
+
+// 音声トラックの CodecID/CodecPrivate/サンプルレート/ch を検証。
+[<Fact>]
+let ``BuildInit の音声トラックを読み戻せる`` () =
+    let init = MatroskaInitBuilder.BuildInit(sampleVideo, sampleAudio)
+    let tracks = readTopLevel init Elements.Tracks
+    // 2 番目の TrackEntry が音声。Tracks の子から TrackEntry を2つ集める。
+    use ms = new MemoryStream(tracks.Data)
+    let entries = System.Collections.Generic.List<Element>()
+    while ms.Position < ms.Length do
+        let mutable h = ElementHeader.Read(ms)
+        let body = Element.ReadBody(&h, ms)
+        if h.ID.BinaryEquals(Elements.TrackEntry) then entries.Add(body)
+    Assert.Equal(2, entries.Count)
+    let audio = entries.[1]
+    let trackType = childOf audio Elements.TrackType
+    Assert.Equal(2L, Element.ReadUInt(new MemoryStream(trackType.Data), trackType.Data.LongLength))
+    let codecId = childOf audio Elements.CodecID
+    Assert.Equal("A_AAC", Encoding.UTF8.GetString(codecId.Data))
+    let codecPrivate = childOf audio Elements.CodecPrivate
+    Assert.Equal<byte[]>(sampleAudio.CodecPrivate, codecPrivate.Data)
+    let asettings = childOf audio Elements.Audio
+    let channels = childOf asettings Elements.Channels
+    Assert.Equal(2L, Element.ReadUInt(new MemoryStream(channels.Data), channels.Data.LongLength))

--- a/PeerCastStation/PeerCastStation.Test/MKVTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/MKVTests.fs
@@ -1,0 +1,99 @@
+module MKVTests
+
+open System.IO
+open System.Text
+open PeerCastStation.MKV
+open Xunit
+
+// VInt.FromSize: 最小バイト長で符号化し、ReadUInt で読み戻すと元の値に一致する。
+// 127/16383/2097151 は全ビット1(unknown size)と衝突するため 1 バイト繰り上がる。
+[<Theory>]
+[<InlineData(0, 1)>]
+[<InlineData(126, 1)>]
+[<InlineData(127, 2)>]
+[<InlineData(128, 2)>]
+[<InlineData(16382, 2)>]
+[<InlineData(16383, 3)>]
+[<InlineData(16384, 3)>]
+[<InlineData(2097150, 3)>]
+[<InlineData(2097151, 4)>]
+let ``VInt.FromSize は最小長で符号化し読み戻せる`` (value: int, expectedLen: int) =
+    let v = VInt.FromSize(int64 value)
+    Assert.Equal(expectedLen, v.Length)
+    use ms = new MemoryStream(v.Binary)
+    let read = VInt.ReadUInt(ms)
+    Assert.Equal(int64 value, read.Value)
+
+[<Fact>]
+let ``VInt.FromSize は4バイト超の値も往復できる`` () =
+    let value = 5_000_000L
+    let v = VInt.FromSize(value)
+    Assert.Equal(4, v.Length)
+    use ms = new MemoryStream(v.Binary)
+    Assert.Equal(value, VInt.ReadUInt(ms).Value)
+
+[<Fact>]
+let ``VInt.FromSize は負値を拒否する`` () =
+    Assert.Throws<System.ArgumentOutOfRangeException>(fun () -> VInt.FromSize(-1L) |> ignore)
+    |> ignore
+
+// MakeElement: ID とデータを保ち、既存リーダーで読み戻せる。
+[<Fact>]
+let ``MakeElement は ID とデータを保ち読み戻せる`` () =
+    let data = [| 0x12uy; 0x34uy; 0x56uy |]
+    let elt = MatroskaWriter.MakeElement(Elements.DocType, data)
+    use ms = new MemoryStream(elt.ToArray())
+    let mutable header = ElementHeader.Read(ms)
+    Assert.True(header.ID.BinaryEquals(Elements.DocType))
+    Assert.Equal(int64 data.Length, header.Size.Value)
+    let read = Element.ReadBody(&header, ms)
+    Assert.Equal<byte[]>(data, read.Data)
+
+// 既知の EBML バイト列(DocType="matroska") を read→write して完全一致。
+[<Fact>]
+let ``既知の EBML バイト列を read write で完全一致`` () =
+    let known =
+        Array.concat [
+            [| 0x42uy; 0x82uy; 0x88uy |] // DocType id + size(len1,val8)
+            Encoding.UTF8.GetBytes("matroska")
+        ]
+    use ms = new MemoryStream(known)
+    let mutable header = ElementHeader.Read(ms)
+    let elt = Element.ReadBody(&header, ms)
+    let rebuilt = MatroskaWriter.MakeElement(header.ID.Binary, elt.Data)
+    Assert.Equal<byte[]>(known, rebuilt.ToArray())
+
+// MakeMaster: 子要素を内包し、ネスト境界とサイズが正しい。
+[<Fact>]
+let ``MakeMaster は子要素を内包し境界が正しい`` () =
+    let child1 = MatroskaWriter.MakeUInt(Elements.TimecodeScale, 1000000UL)
+    let child2 = MatroskaWriter.MakeString(Elements.DocType, "webm")
+    let master = MatroskaWriter.MakeMaster(Elements.Info, child1, child2)
+    use ms = new MemoryStream(master.ToArray())
+    let header = ElementHeader.Read(ms)
+    Assert.True(header.ID.BinaryEquals(Elements.Info))
+
+    let mutable h1 = ElementHeader.Read(ms)
+    Assert.True(h1.ID.BinaryEquals(Elements.TimecodeScale))
+    let c1 = Element.ReadBody(&h1, ms)
+    Assert.Equal(1000000L, Element.ReadUInt(new MemoryStream(c1.Data), c1.Data.LongLength))
+
+    let mutable h2 = ElementHeader.Read(ms)
+    Assert.True(h2.ID.BinaryEquals(Elements.DocType))
+    let c2 = Element.ReadBody(&h2, ms)
+    Assert.Equal("webm", Encoding.UTF8.GetString(c2.Data))
+
+    // master のサイズ = 子要素の合計(余りなく読み切る)
+    Assert.Equal(ms.Length, ms.Position)
+
+// MakeUInt: 最小バイト長で符号なし整数を符号化する。
+[<Theory>]
+[<InlineData(0, 1)>]
+[<InlineData(255, 1)>]
+[<InlineData(256, 2)>]
+[<InlineData(65535, 2)>]
+[<InlineData(65536, 3)>]
+let ``MakeUInt は最小バイト長で符号化する`` (value: int, expectedLen: int) =
+    let elt = MatroskaWriter.MakeUInt(Elements.TimecodeScale, uint64 value)
+    Assert.Equal(expectedLen, elt.Data.Length)
+    Assert.Equal(int64 value, Element.ReadUInt(new MemoryStream(elt.Data), elt.Data.LongLength))

--- a/PeerCastStation/PeerCastStation.Test/MatroskaContentBufferTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/MatroskaContentBufferTests.fs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// (C) 2026 Philmist
 module MatroskaContentBufferTests
 
 open System

--- a/PeerCastStation/PeerCastStation.Test/MatroskaContentBufferTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/MatroskaContentBufferTests.fs
@@ -61,6 +61,17 @@ let private sendVideo (buf: MatroskaContentBuffer) msg = (buf :> IRTMPContentSin
 let private sendAudio (buf: MatroskaContentBuffer) msg = (buf :> IRTMPContentSink).OnAudio(msg)
 let private sendData  (buf: MatroskaContentBuffer) msg = (buf :> IRTMPContentSink).OnData(msg)
 
+// 符号付き 24bit big-endian の CompositionTime(CTS)を 3 バイトにする。
+let private cts24 (v: int) = [ byte ((v >>> 16) &&& 0xFF); byte ((v >>> 8) &&& 0xFF); byte (v &&& 0xFF) ]
+
+// Enhanced RTMP の avc1。avc1/hvc1 だけが CTS をワイヤに乗せる。
+// 映像 avc1 SequenceStart(config)。0x90 = ExHeader|FrameType1|PacketType0。
+let private videoConfigAvc = videoMsg 0L ([0x90uy] @ fourCc "avc1" @ [0x01uy; 0x42uy])
+// avc1 キーフレーム CodedFrames(PacketType1)。0x91 = ExHeader|FrameType1|PacketType1。CTS あり。
+let private videoKeyAvc ts cts = videoMsg ts ([0x91uy] @ fourCc "avc1" @ cts24 cts @ [0xDEuy; 0xADuy])
+// avc1 非キーフレーム CodedFrames。0xA1 = ExHeader|FrameType2|PacketType1。CTS あり。
+let private videoInterAvc ts cts = videoMsg ts ([0xA1uy] @ fourCc "avc1" @ cts24 cts @ [0xBEuy; 0xEFuy])
+
 // config(映像+音声)と onMetaData が揃うと init(EBML→Tracks)を OnContentHeader する。
 [<Fact>]
 let ``config と metadata が揃うと init を OnContentHeader する`` () =
@@ -143,3 +154,72 @@ let ``キーフレームで Cluster を開き SimpleBlock を出力する`` () =
     Assert.True(hBlk2.ID.BinaryEquals(Elements.SimpleBlock))
     let blk2 = Element.ReadBody(&hBlk2, ms1)
     Assert.Equal<byte[]>([| 0x82uy; 0x00uy; 0x14uy; 0x80uy; 0xCAuy; 0xFEuy |], blk2.Data)
+
+// §A: avc1/hvc1 は CTS が乗る。SimpleBlock の timecode は DTS ではなく
+//     PTS(=DTS+CTS)を原点 rebase した値になる。
+[<Fact>]
+let ``avc1 では CTS を加えた PTS で SimpleBlock の timecode を決める`` () =
+    use peca = new PeerCast()
+    let sink = CollectingSink()
+    let buf = MatroskaContentBuffer(makeChannel peca, sink)
+    sendData buf (metaMsg())
+    sendVideo buf videoConfigAvc
+    sendAudio buf audioConfig
+    // キーフレーム DTS=100, CTS=10 → PTS=110。これが出力原点。Cluster timecode=0。
+    sendVideo buf (videoKeyAvc 100L 10)
+    // 非キー DTS=120, CTS=30 → PTS=150 → rebased=40=0x0028。
+    // CTS を無視して DTS だけだと 120-100=20=0x14 になる(=回帰検出)。
+    sendVideo buf (videoInterAvc 120L 30)
+    Assert.Equal(2, sink.Contents.Count)
+
+    // 1 つ目: Cluster(unknown-size) → Timecode(=0, 原点 rebase) → キーフレーム SimpleBlock(相対 0)
+    use ms0 = new MemoryStream(sink.Contents.[0])
+    let hCluster = ElementHeader.Read(ms0)
+    Assert.True(hCluster.ID.BinaryEquals(Elements.Cluster))
+    let mutable hTc = ElementHeader.Read(ms0)
+    Assert.True(hTc.ID.BinaryEquals(Elements.Timecode))
+    let tc = Element.ReadBody(&hTc, ms0)
+    Assert.Equal(0L, Element.ReadUInt(new MemoryStream(tc.Data), tc.Data.LongLength))
+
+    // 2 つ目: 非キー SimpleBlock(track1, 相対 tc=40=0x0028, 非キーなので flag=0x00)
+    use ms1 = new MemoryStream(sink.Contents.[1])
+    let mutable hBlk = ElementHeader.Read(ms1)
+    Assert.True(hBlk.ID.BinaryEquals(Elements.SimpleBlock))
+    let blk = Element.ReadBody(&hBlk, ms1)
+    Assert.Equal<byte[]>([| 0x81uy; 0x00uy; 0x28uy; 0x00uy; 0xBEuy; 0xEFuy |], blk.Data)
+
+// §B-1: onMetaData が来なくても、config が揃って一定数フレームが流れたら
+//       CodecPrivate だけで init をフォールバック送出する。
+[<Fact>]
+let ``metadata が来なくても一定フレーム後に config だけで init を出す`` () =
+    use peca = new PeerCast()
+    let sink = CollectingSink()
+    let buf = MatroskaContentBuffer(makeChannel peca, sink)
+    // metadata は送らない。config だけ揃える。
+    sendVideo buf videoConfig
+    sendAudio buf audioConfig
+    // しきい値(MetadataWaitFrames=60)未満では init は出ない。
+    for i in 1..59 do
+        sendVideo buf (videoKey (int64 i))
+    Assert.Equal(0, sink.Headers.Count)
+    // 60 フレーム目でフォールバック init が出る。
+    sendVideo buf (videoKey 60L)
+    Assert.Equal(1, sink.Headers.Count)
+
+// §E: 相対 timecode が int16(±約32.7秒)を超えたら飽和クランプする(GOP 過大時の安全網)。
+[<Fact>]
+let ``int16 を超える相対 timecode は飽和クランプされる`` () =
+    use peca = new PeerCast()
+    let sink = CollectingSink()
+    let buf = MatroskaContentBuffer(makeChannel peca, sink)
+    sendData buf (metaMsg())
+    sendVideo buf videoConfig
+    sendAudio buf audioConfig
+    sendVideo buf (videoKey 0L)      // Cluster 開始、原点=0
+    sendAudio buf (audioRaw 40000L)  // 相対 40000ms > 32767 → 0x7FFF にクランプ
+    Assert.Equal(2, sink.Contents.Count)
+    use ms1 = new MemoryStream(sink.Contents.[1])
+    let mutable hBlk = ElementHeader.Read(ms1)
+    Assert.True(hBlk.ID.BinaryEquals(Elements.SimpleBlock))
+    let blk = Element.ReadBody(&hBlk, ms1)
+    Assert.Equal<byte[]>([| 0x82uy; 0x7Fuy; 0xFFuy; 0x80uy; 0xCAuy; 0xFEuy |], blk.Data)

--- a/PeerCastStation/PeerCastStation.Test/MatroskaContentBufferTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/MatroskaContentBufferTests.fs
@@ -1,0 +1,145 @@
+module MatroskaContentBufferTests
+
+open System
+open System.IO
+open System.Collections.Generic
+open PeerCastStation.Core
+open PeerCastStation.FLV.AMF
+open PeerCastStation.FLV.RTMP
+open PeerCastStation.MKV
+open TestCommon
+open Xunit
+
+// OnContentHeader/OnContent のバイト列を収集するテスト用 Sink。
+type private CollectingSink() =
+    let headers  = List<byte[]>()
+    let contents = List<byte[]>()
+    let infos    = List<ChannelInfo>()
+    member _.Headers  = headers
+    member _.Contents = contents
+    member _.Infos    = infos
+    interface IContentSink with
+        member _.OnChannelInfo(info)     = infos.Add(info)
+        member _.OnChannelTrack(_)       = ()
+        member _.OnContentHeader(header) = headers.Add(header.Data.ToArray())
+        member _.OnContent(content)      = contents.Add(content.Data.ToArray())
+        member _.OnStop(_)               = ()
+
+let private makeChannel (peca: PeerCast) =
+    DummyBroadcastChannel(peca, NetworkType.IPv4, Guid.NewGuid(), createChannelInfoBitrate "hoge" "MKV" 500, ChannelTrack.empty)
+
+let private videoMsg (timestamp: int64) (bytes: byte list) =
+    RTMPMessage(RTMPMessageType.Video, timestamp, 0L, List.toArray bytes)
+
+let private audioMsg (timestamp: int64) (bytes: byte list) =
+    RTMPMessage(RTMPMessageType.Audio, timestamp, 0L, List.toArray bytes)
+
+let private fourCc (s: string) =
+    System.Text.Encoding.ASCII.GetBytes(s) |> Array.toList
+
+// onMetaData(width/height/samplerate/ch)を運ぶ DataMessage を作る。
+let private metaMsg () =
+    let meta = AMFObject()
+    meta.Add("width", 1920.0)
+    meta.Add("height", 1080.0)
+    meta.Add("audiosamplerate", 48000.0)
+    meta.Add("audiochannels", 2.0)
+    DataAMF0Message(0L, 0L, "onMetaData", [| AMFValue(meta) |])
+
+// 映像 av01 SequenceStart(config)。0x90 = ExHeader|FrameType1|PacketType0。
+let private videoConfig = videoMsg 0L ([0x90uy] @ fourCc "av01" @ [0x81uy; 0x0Cuy])
+// 音声 AAC config(ASC)。0xAF = SoundFormat10|..., AACPacketType 0。
+let private audioConfig = audioMsg 0L [0xAFuy; 0x00uy; 0x12uy; 0x10uy]
+// 映像 av01 キーフレーム。0x93 = ExHeader|FrameType1|PacketType3(CodedFramesX, CTS無し)。
+let private videoKey ts = videoMsg ts ([0x93uy] @ fourCc "av01" @ [0xDEuy; 0xADuy])
+// 映像 av01 非キーフレーム。0xA3 = ExHeader|FrameType2|PacketType3。
+let private videoInter ts = videoMsg ts ([0xA3uy] @ fourCc "av01" @ [0xBEuy; 0xEFuy])
+// 音声 AAC raw。0xAF, AACPacketType 1。
+let private audioRaw ts = audioMsg ts [0xAFuy; 0x01uy; 0xCAuy; 0xFEuy]
+
+let private sendVideo (buf: MatroskaContentBuffer) msg = (buf :> IRTMPContentSink).OnVideo(msg)
+let private sendAudio (buf: MatroskaContentBuffer) msg = (buf :> IRTMPContentSink).OnAudio(msg)
+let private sendData  (buf: MatroskaContentBuffer) msg = (buf :> IRTMPContentSink).OnData(msg)
+
+// config(映像+音声)と onMetaData が揃うと init(EBML→Tracks)を OnContentHeader する。
+[<Fact>]
+let ``config と metadata が揃うと init を OnContentHeader する`` () =
+    use peca = new PeerCast()
+    let sink = CollectingSink()
+    let buf = MatroskaContentBuffer(makeChannel peca, sink)
+    sendData buf (metaMsg())
+    sendVideo buf videoConfig
+    sendAudio buf audioConfig
+    Assert.Equal(1, sink.Headers.Count)
+    let init = sink.Headers.[0]
+    // 先頭は EBML ID(0x1A 0x45 0xDF 0xA3)
+    Assert.Equal<byte[]>([| 0x1Auy; 0x45uy; 0xDFuy; 0xA3uy |], init.[0..3])
+    // Tracks(0x16 0x54 0xAE 0x6B)を含む
+    use ms = new MemoryStream(init)
+    let mutable foundTracks = false
+    while not foundTracks && ms.Position < ms.Length do
+        let mutable h = ElementHeader.Read(ms)
+        if h.ID.BinaryEquals(Elements.Tracks) then foundTracks <- true
+        elif h.Size.IsUnknown then () // Segment は中身を続けて走査
+        else Element.ReadBody(&h, ms) |> ignore
+    Assert.True(foundTracks)
+    // ChannelInfo の ContentType は MKV
+    Assert.Contains(sink.Infos, fun i -> i.ContentType = "MKV")
+
+// metadata が来ないと config が揃っても init を出さない。
+[<Fact>]
+let ``metadata が無いと init を出さない`` () =
+    use peca = new PeerCast()
+    let sink = CollectingSink()
+    let buf = MatroskaContentBuffer(makeChannel peca, sink)
+    sendVideo buf videoConfig
+    sendAudio buf audioConfig
+    Assert.Equal(0, sink.Headers.Count)
+
+// init 後、最初の映像キーフレーム到達までフレームを破棄する。
+[<Fact>]
+let ``最初のキーフレーム前のフレームは破棄される`` () =
+    use peca = new PeerCast()
+    let sink = CollectingSink()
+    let buf = MatroskaContentBuffer(makeChannel peca, sink)
+    sendData buf (metaMsg())
+    sendVideo buf videoConfig
+    sendAudio buf audioConfig
+    sendVideo buf (videoInter 10L) // キーフレーム前の非キー → 破棄
+    sendAudio buf (audioRaw 10L)   // 同上 → 破棄
+    Assert.Equal(0, sink.Contents.Count)
+
+// 映像キーフレームで Cluster(+Timecode)を開き、後続フレームを SimpleBlock にする。
+[<Fact>]
+let ``キーフレームで Cluster を開き SimpleBlock を出力する`` () =
+    use peca = new PeerCast()
+    let sink = CollectingSink()
+    let buf = MatroskaContentBuffer(makeChannel peca, sink)
+    sendData buf (metaMsg())
+    sendVideo buf videoConfig
+    sendAudio buf audioConfig
+    sendVideo buf (videoKey 100L) // 最初のキーフレーム → Cluster 開始(原点=100)
+    sendAudio buf (audioRaw 120L) // 同 Cluster 内 → 相対 timecode=20
+    Assert.Equal(2, sink.Contents.Count)
+
+    // 1 つ目: Cluster header(unknown-size) → Timecode(=0) → SimpleBlock(track1, tc=0, key)
+    use ms0 = new MemoryStream(sink.Contents.[0])
+    let hCluster = ElementHeader.Read(ms0)
+    Assert.True(hCluster.ID.BinaryEquals(Elements.Cluster))
+    Assert.True(hCluster.Size.IsUnknown)
+    let mutable hTc = ElementHeader.Read(ms0)
+    Assert.True(hTc.ID.BinaryEquals(Elements.Timecode))
+    let tc = Element.ReadBody(&hTc, ms0)
+    Assert.Equal(0L, Element.ReadUInt(new MemoryStream(tc.Data), tc.Data.LongLength)) // 原点 rebase で 0
+    let mutable hBlk = ElementHeader.Read(ms0)
+    Assert.True(hBlk.ID.BinaryEquals(Elements.SimpleBlock))
+    let blk = Element.ReadBody(&hBlk, ms0)
+    // track1 VInt=0x81, tc=0(0x0000), keyframe=0x80, payload
+    Assert.Equal<byte[]>([| 0x81uy; 0x00uy; 0x00uy; 0x80uy; 0xDEuy; 0xADuy |], blk.Data)
+
+    // 2 つ目: 音声 SimpleBlock 単体(track2, 相対 tc=20=0x0014, 音声は常に key)
+    use ms1 = new MemoryStream(sink.Contents.[1])
+    let mutable hBlk2 = ElementHeader.Read(ms1)
+    Assert.True(hBlk2.ID.BinaryEquals(Elements.SimpleBlock))
+    let blk2 = Element.ReadBody(&hBlk2, ms1)
+    Assert.Equal<byte[]>([| 0x82uy; 0x00uy; 0x14uy; 0x80uy; 0xCAuy; 0xFEuy |], blk2.Data)

--- a/PeerCastStation/PeerCastStation.Test/MatroskaContentBufferTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/MatroskaContentBufferTests.fs
@@ -14,15 +14,17 @@ open Xunit
 type private CollectingSink() =
     let headers  = List<byte[]>()
     let contents = List<byte[]>()
+    let contFlags = List<PCPChanPacketContinuation>()
     let infos    = List<ChannelInfo>()
     member _.Headers  = headers
     member _.Contents = contents
+    member _.ContFlags = contFlags
     member _.Infos    = infos
     interface IContentSink with
         member _.OnChannelInfo(info)     = infos.Add(info)
         member _.OnChannelTrack(_)       = ()
         member _.OnContentHeader(header) = headers.Add(header.Data.ToArray())
-        member _.OnContent(content)      = contents.Add(content.Data.ToArray())
+        member _.OnContent(content)      = contents.Add(content.Data.ToArray()); contFlags.Add(content.ContFlag)
         member _.OnStop(_)               = ()
 
 let private makeChannel (peca: PeerCast) =
@@ -205,6 +207,28 @@ let ``metadata が来なくても一定フレーム後に config だけで init 
     // 60 フレーム目でフォールバック init が出る。
     sendVideo buf (videoKey 60L)
     Assert.Equal(1, sink.Headers.Count)
+
+// 後発参加者のリシンク: Cluster を開く映像キーフレームのパケットだけ ContFlag=None、
+// 中間フレームは InterFrame、音声は AudioFrame。これにより Core の GetFirstContent が
+// 後発参加者を必ず Cluster 境界(キーフレーム)から開始させ、孤児 SimpleBlock を防ぐ。
+[<Fact>]
+let ``ContFlag はキーフレームのみ None、中間は InterFrame、音声は AudioFrame`` () =
+    use peca = new PeerCast()
+    let sink = CollectingSink()
+    let buf = MatroskaContentBuffer(makeChannel peca, sink)
+    sendData buf (metaMsg())
+    sendVideo buf videoConfig
+    sendAudio buf audioConfig
+    sendVideo buf (videoKey 0L)     // キーフレーム → Cluster 開始 → None
+    sendAudio buf (audioRaw 10L)    // 音声 → AudioFrame
+    sendVideo buf (videoInter 20L)  // 中間フレーム → InterFrame
+    sendVideo buf (videoKey 100L)   // 次のキーフレーム → 新 Cluster → None
+    Assert.Equal<PCPChanPacketContinuation[]>(
+        [| PCPChanPacketContinuation.None
+           PCPChanPacketContinuation.AudioFrame
+           PCPChanPacketContinuation.InterFrame
+           PCPChanPacketContinuation.None |],
+        sink.ContFlags.ToArray())
 
 // §E: 相対 timecode が int16(±約32.7秒)を超えたら飽和クランプする(GOP 過大時の安全網)。
 [<Fact>]

--- a/PeerCastStation/PeerCastStation.Test/MatroskaContentBufferTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/MatroskaContentBufferTests.fs
@@ -230,6 +230,41 @@ let ``ContFlag はキーフレームのみ None、中間は InterFrame、音声�
            PCPChanPacketContinuation.None |],
         sink.ContFlags.ToArray())
 
+// 時間境界 Cluster: GOP(キーフレーム間隔)が長くても、前 Cluster から ClusterTimeLimitMs
+// (1000ms)以上経過した映像フレームで新 Cluster(ContFlag=None の join 点)を開く。
+// これにより内容バッファ(3秒)より長い GOP でも直近 join 点がバッファ内に残る。
+[<Fact>]
+let ``GOP が長くても一定時間ごとに Cluster(None join点)を開く`` () =
+    use peca = new PeerCast()
+    let sink = CollectingSink()
+    let buf = MatroskaContentBuffer(makeChannel peca, sink)
+    sendData buf (metaMsg())
+    sendVideo buf videoConfig
+    sendAudio buf audioConfig
+    sendVideo buf (videoKey 0L)      // キーフレーム → Cluster 開始(原点0)
+    sendVideo buf (videoInter 500L)  // +500ms: しきい値未満 → 新 Cluster 無し → InterFrame
+    sendVideo buf (videoInter 1200L) // +1200ms: しきい値超 → 非キーフレームでも新 Cluster → None
+    Assert.Equal(3, sink.Contents.Count)
+    Assert.Equal<PCPChanPacketContinuation[]>(
+        [| PCPChanPacketContinuation.None         // キーフレーム Cluster
+           PCPChanPacketContinuation.InterFrame   // しきい値未満の中間フレーム
+           PCPChanPacketContinuation.None |],      // 時間境界 Cluster(非キーフレーム始まり)
+        sink.ContFlags.ToArray())
+    // 3 つ目は Cluster ヘッダ(unknown-size)+ Timecode(=1200, 原点 rebase)で始まる。
+    use ms2 = new MemoryStream(sink.Contents.[2])
+    let hCluster = ElementHeader.Read(ms2)
+    Assert.True(hCluster.ID.BinaryEquals(Elements.Cluster))
+    Assert.True(hCluster.Size.IsUnknown)
+    let mutable hTc = ElementHeader.Read(ms2)
+    Assert.True(hTc.ID.BinaryEquals(Elements.Timecode))
+    let tc = Element.ReadBody(&hTc, ms2)
+    Assert.Equal(1200L, Element.ReadUInt(new MemoryStream(tc.Data), tc.Data.LongLength))
+    // 続く SimpleBlock は新 Cluster 基準で相対 timecode=0、非キーフレーム(flag=0x00)。
+    let mutable hBlk = ElementHeader.Read(ms2)
+    Assert.True(hBlk.ID.BinaryEquals(Elements.SimpleBlock))
+    let blk = Element.ReadBody(&hBlk, ms2)
+    Assert.Equal<byte[]>([| 0x81uy; 0x00uy; 0x00uy; 0x00uy; 0xBEuy; 0xEFuy |], blk.Data)
+
 // §E: 相対 timecode が int16(±約32.7秒)を超えたら飽和クランプする(GOP 過大時の安全網)。
 [<Fact>]
 let ``int16 を超える相対 timecode は飽和クランプされる`` () =

--- a/PeerCastStation/PeerCastStation.Test/MatroskaContentBufferTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/MatroskaContentBufferTests.fs
@@ -159,8 +159,8 @@ let ``キーフレームで Cluster を開き SimpleBlock を出力する`` () =
     let blk2 = Element.ReadBody(&hBlk2, ms1)
     Assert.Equal<byte[]>([| 0x82uy; 0x00uy; 0x14uy; 0x80uy; 0xCAuy; 0xFEuy |], blk2.Data)
 
-// §A: avc1/hvc1 は CTS が乗る。SimpleBlock の timecode は DTS ではなく
-//     PTS(=DTS+CTS)を原点 rebase した値になる。
+// avc1/hvc1 は CTS が乗る。SimpleBlock の timecode は DTS ではなく
+// PTS(=DTS+CTS)を原点 rebase した値になる。
 [<Fact>]
 let ``avc1 では CTS を加えた PTS で SimpleBlock の timecode を決める`` () =
     use peca = new PeerCast()
@@ -192,8 +192,8 @@ let ``avc1 では CTS を加えた PTS で SimpleBlock の timecode を決める
     let blk = Element.ReadBody(&hBlk, ms1)
     Assert.Equal<byte[]>([| 0x81uy; 0x00uy; 0x28uy; 0x00uy; 0xBEuy; 0xEFuy |], blk.Data)
 
-// §B-1: onMetaData が来なくても、config が揃って一定数フレームが流れたら
-//       CodecPrivate だけで init をフォールバック送出する。
+// onMetaData が来なくても、config が揃って一定数フレームが流れたら
+// CodecPrivate だけで init をフォールバック送出する。
 [<Fact>]
 let ``metadata が来なくても一定フレーム後に config だけで init を出す`` () =
     use peca = new PeerCast()
@@ -267,7 +267,7 @@ let ``GOP が長くても一定時間ごとに Cluster(None join点)を開く`` 
     let blk = Element.ReadBody(&hBlk, ms2)
     Assert.Equal<byte[]>([| 0x81uy; 0x00uy; 0x00uy; 0x00uy; 0xBEuy; 0xEFuy |], blk.Data)
 
-// §E: 相対 timecode が int16(±約32.7秒)を超えたら飽和クランプする(GOP 過大時の安全網)。
+// 相対 timecode が int16(±約32.7秒)を超えたら飽和クランプする(GOP 過大時の安全網)。
 [<Fact>]
 let ``int16 を超える相対 timecode は飽和クランプされる`` () =
     use peca = new PeerCast()

--- a/PeerCastStation/PeerCastStation.Test/PeerCastStation.Test.fsproj
+++ b/PeerCastStation/PeerCastStation.Test/PeerCastStation.Test.fsproj
@@ -48,6 +48,7 @@
     <Compile Include="TestCommon.fs" />
     <Compile Include="MKVTests.fs" />
     <Compile Include="RTMPConnectTests.fs" />
+    <Compile Include="RTMPDepacketizerTests.fs" />
     <Compile Include="Atom.fs" />
     <Compile Include="CoreTests.fs" />
     <Compile Include="OWINTest.fs" />

--- a/PeerCastStation/PeerCastStation.Test/PeerCastStation.Test.fsproj
+++ b/PeerCastStation/PeerCastStation.Test/PeerCastStation.Test.fsproj
@@ -47,6 +47,7 @@
     </None>
     <Compile Include="TestCommon.fs" />
     <Compile Include="MKVTests.fs" />
+    <Compile Include="RTMPConnectTests.fs" />
     <Compile Include="Atom.fs" />
     <Compile Include="CoreTests.fs" />
     <Compile Include="OWINTest.fs" />

--- a/PeerCastStation/PeerCastStation.Test/PeerCastStation.Test.fsproj
+++ b/PeerCastStation/PeerCastStation.Test/PeerCastStation.Test.fsproj
@@ -49,6 +49,7 @@
     <Compile Include="MKVTests.fs" />
     <Compile Include="RTMPConnectTests.fs" />
     <Compile Include="RTMPDepacketizerTests.fs" />
+    <Compile Include="MatroskaContentBufferTests.fs" />
     <Compile Include="Atom.fs" />
     <Compile Include="CoreTests.fs" />
     <Compile Include="OWINTest.fs" />

--- a/PeerCastStation/PeerCastStation.Test/PeerCastStation.Test.fsproj
+++ b/PeerCastStation/PeerCastStation.Test/PeerCastStation.Test.fsproj
@@ -6,6 +6,9 @@
     <IsPackable>false</IsPackable>
 
     <Platforms>AnyCPU;x86;x64</Platforms>
+
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\PeerCastStation.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -43,6 +46,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <Compile Include="TestCommon.fs" />
+    <Compile Include="MKVTests.fs" />
     <Compile Include="Atom.fs" />
     <Compile Include="CoreTests.fs" />
     <Compile Include="OWINTest.fs" />

--- a/PeerCastStation/PeerCastStation.Test/RTMPConnectTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/RTMPConnectTests.fs
@@ -1,0 +1,71 @@
+module RTMPConnectTests
+
+open System.Collections.Generic
+open PeerCastStation.FLV.AMF
+open PeerCastStation.FLV.RTMP
+open Xunit
+
+// StrictArray の AMFValue を文字列列から作る。
+let private strictArray (items: string seq) =
+    let values = items |> Seq.map (fun s -> AMFValue(s)) |> Seq.toArray
+    AMFValue(values :> IEnumerable<AMFValue>)
+
+// ECMAArray(キーが FourCC のマップ)の AMFValue を作る。値は適当な番号。
+let private ecmaArray (items: string seq) =
+    let dic = Dictionary<string, AMFValue>()
+    items |> Seq.iteri (fun i s -> dic.Add(s, AMFValue(i)))
+    AMFValue(dic :> IDictionary<string, AMFValue>)
+
+// command_object を AMF0 で直列化 → 読み戻して CommandAMF0Message にする。
+let private roundTripCommand (commandName: string) (commandObject: AMFValue) =
+    let created = CommandMessage.Create(0, 0L, 0L, commandName, 1, commandObject, Array.empty<AMFValue>)
+    let raw = RTMPMessage(created.MessageType, created.Timestamp, created.StreamId, created.Body)
+    CommandAMF0Message(raw)
+
+// connect の CommandObject 内 fourCcList(StrictArray)を AMF バイト往復後に抽出できる。
+[<Fact>]
+let ``connect の fourCcList(StrictArray)を抽出できる`` () =
+    let co = AMFObject()
+    co.Add("app", "live")
+    co.Add("fourCcList", strictArray ["av01"; "hvc1"])
+    let parsed = roundTripCommand "connect" (AMFValue(co))
+    let list = EnhancedRTMP.ParseClientFourCcList(parsed.CommandObject) |> Seq.toArray
+    Assert.Equal<string[]>([| "av01"; "hvc1" |], list)
+
+// fourCcList が無ければ Enhanced RTMP v2 の videoFourCcInfoMap のキーを使う。
+[<Fact>]
+let ``fourCcList が無ければ videoFourCcInfoMap のキーを使う`` () =
+    let co = AMFObject()
+    co.Add("videoFourCcInfoMap", ecmaArray ["av01"; "avc1"])
+    let parsed = roundTripCommand "connect" (AMFValue(co))
+    let list = EnhancedRTMP.ParseClientFourCcList(parsed.CommandObject) |> Set.ofSeq
+    Assert.Equal<Set<string>>(Set.ofList ["av01"; "avc1"], list)
+
+// クライアントが何も指定しなければ全サポートコーデックを広告する。
+[<Fact>]
+let ``fourCcList 未指定なら全サポートコーデックを広告する`` () =
+    let result = EnhancedRTMP.NegotiateVideoFourCc(Array.empty<string>)
+    Assert.Equal<string[]>(EnhancedRTMP.SupportedVideoFourCc, result)
+
+// 広告するのはクライアントとの交差で、順序はサポート一覧基準。
+[<Fact>]
+let ``広告コーデックはクライアントとの交差をサポート順で返す`` () =
+    let result1 = EnhancedRTMP.NegotiateVideoFourCc([| "av01"; "vp09" |])
+    Assert.Equal<string[]>([| "av01" |], result1)
+    // クライアントの並びに依らずサポート一覧(av01, hvc1, avc1)の順で返る。
+    let result2 = EnhancedRTMP.NegotiateVideoFourCc([| "hvc1"; "av01" |])
+    Assert.Equal<string[]>([| "av01"; "hvc1" |], result2)
+
+// _result 応答に載せた capsEx / fourCcList が AMF 往復で復元される。
+[<Fact>]
+let ``_result 応答の capsEx と fourCcList が往復で復元される`` () =
+    let info = AMFObject()
+    info.Add("code", "NetConnection.Connect.Success")
+    info.Add("capsEx", EnhancedRTMP.CapsEx)
+    info.Add("fourCcList", strictArray (EnhancedRTMP.SupportedVideoFourCc))
+    let parsed = roundTripCommand "_result" (AMFValue(info))
+    let co = parsed.CommandObject
+    Assert.True(co.ContainsKey("capsEx"))
+    Assert.Equal(float EnhancedRTMP.CapsEx, co.["capsEx"].Value :?> float)
+    let list = EnhancedRTMP.ParseClientFourCcList(co) |> Seq.toArray
+    Assert.Equal<string[]>(EnhancedRTMP.SupportedVideoFourCc, list)

--- a/PeerCastStation/PeerCastStation.Test/RTMPConnectTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/RTMPConnectTests.fs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// (C) 2026 Philmist
 module RTMPConnectTests
 
 open System.Collections.Generic

--- a/PeerCastStation/PeerCastStation.Test/RTMPDepacketizerTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/RTMPDepacketizerTests.fs
@@ -1,0 +1,133 @@
+module RTMPDepacketizerTests
+
+open System
+open PeerCastStation.FLV.RTMP
+open Xunit
+
+// バイト列から映像 RTMPMessage を作る。
+let private videoMsg (timestamp: int64) (bytes: byte list) =
+    RTMPMessage(RTMPMessageType.Video, timestamp, 0L, List.toArray bytes)
+
+// バイト列から音声 RTMPMessage を作る。
+let private audioMsg (timestamp: int64) (bytes: byte list) =
+    RTMPMessage(RTMPMessageType.Audio, timestamp, 0L, List.toArray bytes)
+
+// FourCC 文字列をバイト列にする。
+let private fourCc (s: string) =
+    System.Text.Encoding.ASCII.GetBytes(s) |> Array.toList
+
+// Payload を byte[] として取り出す。
+let private payloadBytes (frame: DepacketizedFrame) =
+    frame.Payload.ToArray()
+
+// --- 旧 FLV 映像(AVC) ---
+
+[<Fact>]
+let ``旧FLV AVC config を SequenceHeader/key として正規化する`` () =
+    // 0x17 = (FrameType 1 keyframe)<<4 | (CodecID 7 AVC), AVCPacketType 0, CTS 0, 本体
+    let msg = videoMsg 0L [0x17uy; 0x00uy; 0x00uy; 0x00uy; 0x00uy; 0x01uy; 0x64uy]
+    let ok, frame = ERTMPDepacketizer.TryParseVideo(msg)
+    Assert.True(ok)
+    Assert.Equal(DepacketizedTrackType.Video, frame.TrackType)
+    Assert.Equal("avc1", frame.FourCc)
+    Assert.Equal(DepacketizedFrameKind.SequenceHeader, frame.Kind)
+    Assert.True(frame.IsKeyFrame)
+    Assert.Equal<byte[]>([| 0x01uy; 0x64uy |], payloadBytes frame)
+
+[<Fact>]
+let ``旧FLV AVC NALU の CTS 正値を復元しCodedFrame にする`` () =
+    // 0x27 = (FrameType 2 interframe)<<4 | 7, AVCPacketType 1, CTS = 0x000102 = 258
+    let msg = videoMsg 1000L [0x27uy; 0x01uy; 0x00uy; 0x01uy; 0x02uy; 0xAAuy; 0xBBuy]
+    let ok, frame = ERTMPDepacketizer.TryParseVideo(msg)
+    Assert.True(ok)
+    Assert.Equal(DepacketizedFrameKind.CodedFrame, frame.Kind)
+    Assert.False(frame.IsKeyFrame)
+    Assert.Equal(258, frame.CompositionTimeOffset)
+    Assert.Equal(1000L, frame.Timestamp)
+    Assert.Equal<byte[]>([| 0xAAuy; 0xBBuy |], payloadBytes frame)
+
+[<Fact>]
+let ``旧FLV AVC NALU の CTS 負値を符号復元する`` () =
+    // CTS = 0xFFFFFE = -2
+    let msg = videoMsg 0L [0x27uy; 0x01uy; 0xFFuy; 0xFFuy; 0xFEuy; 0xAAuy]
+    let ok, frame = ERTMPDepacketizer.TryParseVideo(msg)
+    Assert.True(ok)
+    Assert.Equal(-2, frame.CompositionTimeOffset)
+
+// --- 旧 FLV 音声(AAC) ---
+
+[<Fact>]
+let ``旧FLV AAC config を mp4a/SequenceHeader にする`` () =
+    // 0xAF = (SoundFormat 10 AAC)<<4 | ..., AACPacketType 0 (ASC)
+    let msg = audioMsg 0L [0xAFuy; 0x00uy; 0x12uy; 0x10uy]
+    let ok, frame = ERTMPDepacketizer.TryParseAudio(msg)
+    Assert.True(ok)
+    Assert.Equal(DepacketizedTrackType.Audio, frame.TrackType)
+    Assert.Equal("mp4a", frame.FourCc)
+    Assert.Equal(DepacketizedFrameKind.SequenceHeader, frame.Kind)
+    Assert.Equal<byte[]>([| 0x12uy; 0x10uy |], payloadBytes frame)
+
+[<Fact>]
+let ``旧FLV AAC raw を CodedFrame にする`` () =
+    let msg = audioMsg 0L [0xAFuy; 0x01uy; 0xDEuy; 0xADuy]
+    let ok, frame = ERTMPDepacketizer.TryParseAudio(msg)
+    Assert.True(ok)
+    Assert.Equal(DepacketizedFrameKind.CodedFrame, frame.Kind)
+    Assert.Equal<byte[]>([| 0xDEuy; 0xADuy |], payloadBytes frame)
+
+// --- Enhanced RTMP 映像 ---
+
+[<Fact>]
+let ``Enhanced SequenceStart(av01) を FourCC/SequenceHeader/key にする`` () =
+    // 0x80 (ExHeader) | (FrameType 1)<<4 | (PacketType 0 SequenceStart) = 0x90
+    let msg = videoMsg 0L ([0x90uy] @ fourCc "av01" @ [0x81uy; 0x0Cuy])
+    let ok, frame = ERTMPDepacketizer.TryParseVideo(msg)
+    Assert.True(ok)
+    Assert.Equal("av01", frame.FourCc)
+    Assert.Equal(DepacketizedFrameKind.SequenceHeader, frame.Kind)
+    Assert.True(frame.IsKeyFrame)
+    Assert.Equal<byte[]>([| 0x81uy; 0x0Cuy |], payloadBytes frame)
+
+[<Fact>]
+let ``Enhanced CodedFrames(hvc1) は3byteCTSを読みPayloadは8byte目から`` () =
+    // 0x80 | (FrameType 2)<<4 | (PacketType 1 CodedFrames) = 0xA1, CTS = 0x000005 = 5
+    let msg = videoMsg 500L ([0xA1uy] @ fourCc "hvc1" @ [0x00uy; 0x00uy; 0x05uy; 0x11uy; 0x22uy])
+    let ok, frame = ERTMPDepacketizer.TryParseVideo(msg)
+    Assert.True(ok)
+    Assert.Equal("hvc1", frame.FourCc)
+    Assert.Equal(DepacketizedFrameKind.CodedFrame, frame.Kind)
+    Assert.False(frame.IsKeyFrame)
+    Assert.Equal(5, frame.CompositionTimeOffset)
+    Assert.Equal<byte[]>([| 0x11uy; 0x22uy |], payloadBytes frame)
+
+[<Fact>]
+let ``Enhanced CodedFramesX は CTS=0 でPayloadは5byte目から`` () =
+    // 0x80 | (FrameType 1)<<4 | (PacketType 3 CodedFramesX) = 0x93
+    let msg = videoMsg 0L ([0x93uy] @ fourCc "av01" @ [0x33uy; 0x44uy; 0x55uy])
+    let ok, frame = ERTMPDepacketizer.TryParseVideo(msg)
+    Assert.True(ok)
+    Assert.Equal(DepacketizedFrameKind.CodedFrame, frame.Kind)
+    Assert.True(frame.IsKeyFrame)
+    Assert.Equal(0, frame.CompositionTimeOffset)
+    Assert.Equal<byte[]>([| 0x33uy; 0x44uy; 0x55uy |], payloadBytes frame)
+
+// --- 異常系 ---
+
+[<Fact>]
+let ``空Bodyの映像はfalseを返す`` () =
+    let msg = videoMsg 0L []
+    let ok, _ = ERTMPDepacketizer.TryParseVideo(msg)
+    Assert.False(ok)
+
+[<Fact>]
+let ``Enhancedで FourCC に満たない短いBodyはfalseを返す`` () =
+    // ExHeader だが byte1-4 の FourCC が揃わない。
+    let msg = videoMsg 0L [0x90uy; 0x61uy; 0x76uy]
+    let ok, _ = ERTMPDepacketizer.TryParseVideo(msg)
+    Assert.False(ok)
+
+[<Fact>]
+let ``音声でないメッセージを TryParseAudio はfalseにする`` () =
+    let msg = videoMsg 0L [0xAFuy; 0x00uy]
+    let ok, _ = ERTMPDepacketizer.TryParseAudio(msg)
+    Assert.False(ok)

--- a/PeerCastStation/PeerCastStation.Test/RTMPDepacketizerTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/RTMPDepacketizerTests.fs
@@ -101,6 +101,19 @@ let ``Enhanced CodedFrames(hvc1) は3byteCTSを読みPayloadは8byte目から`` 
     Assert.Equal<byte[]>([| 0x11uy; 0x22uy |], payloadBytes frame)
 
 [<Fact>]
+let ``Enhanced CodedFrames(av01) は CTS を食わずPayloadは5byte目から`` () =
+    // av01 は CodedFrames でも CompositionTime を持たない(Enhanced RTMP 仕様)。
+    // 0x80 | (FrameType 1)<<4 | (PacketType 1 CodedFrames) = 0x91
+    // FourCC 直後(5byte目)から OBU ストリーム。3byte 食うと壊れる。
+    let msg = videoMsg 500L ([0x91uy] @ fourCc "av01" @ [0x12uy; 0x00uy; 0x32uy; 0x10uy])
+    let ok, frame = ERTMPDepacketizer.TryParseVideo(msg)
+    Assert.True(ok)
+    Assert.Equal("av01", frame.FourCc)
+    Assert.Equal(DepacketizedFrameKind.CodedFrame, frame.Kind)
+    Assert.Equal(0, frame.CompositionTimeOffset)
+    Assert.Equal<byte[]>([| 0x12uy; 0x00uy; 0x32uy; 0x10uy |], payloadBytes frame)
+
+[<Fact>]
 let ``Enhanced CodedFramesX は CTS=0 でPayloadは5byte目から`` () =
     // 0x80 | (FrameType 1)<<4 | (PacketType 3 CodedFramesX) = 0x93
     let msg = videoMsg 0L ([0x93uy] @ fourCc "av01" @ [0x33uy; 0x44uy; 0x55uy])

--- a/PeerCastStation/PeerCastStation.Test/RTMPDepacketizerTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/RTMPDepacketizerTests.fs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// (C) 2026 Philmist
 module RTMPDepacketizerTests
 
 open System


### PR DESCRIPTION
## 概要

OBSがEnhanced RTMP(以下E-RTMP)でAV1やHEVCを出せるようになっているので
PeerCastでもAV1やHEVCを使いたいよねというPRです。
FLVにはAV1等を乗せられないので別形式にする必要があります。

MKVなので視聴はmpvやvlcなどを想定しています。
このPRではE-RTMPに乗せられる他のコーデック(OpusやFLACなど)には対応していません。
ffmpeg経路ではないOBSではE-RTMPの音声コーデックにAACしか選べないのでAACを乗せられないWebMには対応していません。
同様にE-RTMPで対応している映像や音声が2つ以上になるマルチトラックに関してもffmpeg経路ではないOBSでは使えないので対応していません。

## 動作

PeerCastStationでソースにRTMPを選んでOBSからE-RTMPを受けとった時に
AV1かHEVCだった時にMKVにmuxしてリレーに流します。
H.264だった時は従来のFLV経路に流します。

この動作の関係で映像コーデックが判明するまではリレーを行えないため、
従来よりリレー開始が遅れます。

## 既知の制限および作法の破壊

* キーフレーム間隔が3秒より長い場合、少なくともmpvでは最初のキーフレーム到着まで再生されません。自動設定で映像に動きが無い場合に問題になる可能性があります(というかなった)。
* MKVのBlockGroup-ReferenceBlockを参照したBフレームはほぼ対応していません(OBSで言う"Bフレームを参照:無効"が前提)。
* 配信中の解像度変化やコーデック変更には対応していません。
* 署名アセンブリに追加したinternalな関数をテストする関係でInternalVisibleToと署名アセンブリの設定を追加しています。
* GitHub Actionsでの動作は未確認です。