### PR TITLE
64KBを超える映像PESのpacket_lengthを0にする

### DIFF
--- a/PeerCastStation/PeerCastStation.FLV/FLVToMPEG2TS.cs
+++ b/PeerCastStation/PeerCastStation.FLV/FLVToMPEG2TS.cs
@@ -382,6 +382,10 @@ namespace PeerCastStation.FLV
           };
         }
         var packet_length = pkt.Payload.Length + 3 + pes_header_data.Length;
+        // Video PES packets may use an unspecified length when they exceed 16 bits.
+        if ((pkt.StreamId & 0xF0) == 0xE0 && packet_length > UInt16.MaxValue) {
+          packet_length = 0;
+        }
 
         s.Write(PESStartPrefix, 0, PESStartPrefix.Length);
         s.WriteByte(pkt.StreamId);

--- a/PeerCastStation/PeerCastStation.Test/FLVTests.fs
+++ b/PeerCastStation/PeerCastStation.Test/FLVTests.fs
@@ -1,0 +1,30 @@
+module FLVTests
+
+open System
+open System.IO
+open Xunit
+open PeerCastStation.FLV
+
+[<Fact>]
+let ``Oversized video PES packet uses unspecified packet length`` () =
+    let payload = Array.zeroCreate<byte> 70_000
+    let packet = FLVToMPEG2TS.PESPacket(0xE0uy, Nullable(), Nullable(), payload)
+    use output = new MemoryStream()
+
+    FLVToMPEG2TS.PESPacket.WriteTo(output, packet)
+
+    let bytes = output.ToArray()
+    Assert.Equal(0uy, bytes.[4])
+    Assert.Equal(0uy, bytes.[5])
+
+[<Fact>]
+let ``Normal video PES packet preserves packet length`` () =
+    let payload = Array.zeroCreate<byte> 100
+    let packet = FLVToMPEG2TS.PESPacket(0xE0uy, Nullable(), Nullable(), payload)
+    use output = new MemoryStream()
+
+    FLVToMPEG2TS.PESPacket.WriteTo(output, packet)
+
+    let bytes = output.ToArray()
+    Assert.Equal(0uy, bytes.[4])
+    Assert.Equal(103uy, bytes.[5])

--- a/PeerCastStation/PeerCastStation.Test/PeerCastStation.Test.fsproj
+++ b/PeerCastStation/PeerCastStation.Test/PeerCastStation.Test.fsproj
@@ -45,6 +45,7 @@
     <Compile Include="TestCommon.fs" />
     <Compile Include="Atom.fs" />
     <Compile Include="CoreTests.fs" />
+    <Compile Include="FLVTests.fs" />
     <Compile Include="OWINTest.fs" />
     <Compile Include="ChannelTests.fs" />
     <Compile Include="HttpTests.fs" />


### PR DESCRIPTION
## 概要

FLVからMPEG-2 TSへ変換する際、64 KiBを超える映像PESの`PES_packet_length`を`0`（長さ未指定）で出力するようにします。

あわせて、64 KiB超の映像PESと通常サイズの映像PESに対する回帰テストを追加しました。

## 原因

現在はペイロードとヘッダーを合計した`packet_length`を、そのまま`WriteUInt16BE`へ渡しています。合計が65535を超えると下位16 bitへ折り返され、実際のPESサイズとヘッダー値が一致しないTSが生成されます。

この不一致により、実際のHLSセグメントで`PES packet size mismatch` / `Packet corrupt`が発生し、Apple AVFoundationでは映像フレームをデコードできないケースを確認しました。

映像stream ID（`0xE0`〜`0xEF`）のPESは長さに`0`を使用できるため、16 bit上限を超える場合だけ`0`へ切り替えます。通常サイズと音声PESの挙動は変更しません。

## 確認

- 修正前: 70,000 byteの映像ペイロードに対する新規テストが失敗（期待値`0`、実際の上位byte`17`）
- 修正後: FLV回帰テスト2件が成功
- `dotnet test PeerCastStation/PeerCastStation.Test/PeerCastStation.Test.fsproj -c Release`: 66件すべて成功
